### PR TITLE
create Caddy certs folder before start of the Caddy

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -58,6 +58,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 
 	// Init shared Caddy if not exists
 	caddyConfig := bitswanConfig + "caddy"
+caddyCertsDir := caddyConfig + "/certs"
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -102,6 +103,12 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 
 		caddyProjectName := "bitswan-caddy"
 		caddyDockerComposeCom := exec.Command("docker", "compose", "-p", caddyProjectName, "up", "-d")
+
+		if _, err := os.Stat(caddyCertsDir); os.IsNotExist(err) {
+			if err := os.MkdirAll(caddyCertsDir, 0740); err != nil {
+				return fmt.Errorf("failed to create Caddy certs directory: %w", err)
+			}
+		}
 
 		fmt.Println("Starting Caddy...")
 		if err := caddyDockerComposeCom.Run(); err != nil {


### PR DESCRIPTION
When `certs` folder in `caddy` folder is not being created before Caddy starts the folder is being created due to the mount of docker volumes and have `root` permissions which causing `permission denied` erros