### PR TITLE
Caddy setup set to only happen when it's not present 

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -139,8 +139,9 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	caddy_running := true
 	if err != nil {
 		caddy_running = false
+	} else {
+		defer resp.Body.Close()
 	}
-	defer resp.Body.Close()
 
 	if !caddy_running {
 		fmt.Println("Setting up Caddy...")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -131,7 +132,17 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	if _, err := os.Stat(caddyConfig); os.IsNotExist(err) {
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Get("http://localhost:2019")
+	caddy_running := true
+	if err != nil {
+		caddy_running = false
+	}
+	defer resp.Body.Close()
+
+	if !caddy_running {
 		fmt.Println("Setting up Caddy...")
 		if err := os.MkdirAll(caddyConfig, 0755); err != nil {
 			return fmt.Errorf("failed to create Caddy config directory: %w", err)
@@ -194,6 +205,8 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		}
 
 		fmt.Println("Caddy started successfully!")
+	} else {
+		fmt.Println("A running instance of Caddy with admin found")
 	}
 
 	if o.certsDir != "" {


### PR DESCRIPTION
Caddy setup will now only trigger if there isn't already a Caddy instance running, with admin exposed at `localhost:2019`