### PR TITLE
Mkcerts flag - automatically generate certs when installing the gitops locally using the mkcerts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,19 +98,10 @@ Add the CA certificate to Chrome by:
 3. Click "Import" and select the ca.crt file
 4. Check all trust settings and click "OK"
 
-Now generate the wildcard certificates:
-```
-mkcert "*.bitswan.localhost"
-
-mv _wildcard.bitswan.localhost-key.pem private-key.pem
-mv _wildcard.bitswan.localhost.pem full-chain.pem
-
-```
-
 And finally setup the gitops.
 
 ```sh
-bitswan-gitops-cli init --domain=bitswan.localhost --certs-dir=$PWD dev-gitops
+bitswan-gitops-cli init --domain=bitswan.localhost --mkcerts dev-gitops
 ```
 
 You should be able to access the editor in chrome via https://editor.localhost.

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ This is for setting up gitops locally without first setting up a domain name or 
 First add to /etc/hosts:
 
 ```sh
-      127.0.0.1 editor.bitswan.localhost
-      127.0.0.1 gitops.bitswan.localhost
+      127.0.0.1 bitswan-editor.bitswan.localhost
+      127.0.0.1 bitswan-gitops.bitswan.localhost
       127.0.0.1 testpipeline.bitswan.localhost
 ```
 
-Create some certs for these domains using a certificate authority you setup for yourself. 
+Create some certs for these domains using a certificate authority you setup for yourself.
 
 ```sh
 mkdir bitswan-certs
@@ -104,7 +104,7 @@ And finally setup the gitops.
 bitswan-gitops-cli init --domain=bitswan.localhost --mkcerts dev-gitops
 ```
 
-You should be able to access the editor in chrome via https://editor.localhost.
+You should be able to access the editor in chrome via [https://dev-gitops-editor.bitswan.localhost](https://dev-gitops-editor.bitswan.localhost).
 
 You can get the password to the editor using the command:
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,12 +17,12 @@ import (
 )
 
 type initOptions struct {
-	remoteRepo string
-	domain     string
-	certsDir   string
-	verbose   bool
-	mkCerts    bool
-	noIde      bool
+	remoteRepo  string
+	domain      string
+	certsDir    string
+	verbose     bool
+	mkCerts     bool
+	noIde       bool
 	gitopsImage string
 	editorImage string
 }
@@ -96,7 +96,7 @@ func checkNetworkExists(networkName string) (bool, error) {
 	return false, nil
 }
 
-func runCommandVerbose(cmd *exec.Cmd, verbose bool) (error) {
+func runCommandVerbose(cmd *exec.Cmd, verbose bool) error {
 	var err error
 	if verbose {
 		var stdout, stderr bytes.Buffer
@@ -114,46 +114,46 @@ func runCommandVerbose(cmd *exec.Cmd, verbose bool) (error) {
 }
 
 func generateWildcardCerts(domain string) (string, error) {
-    // Create temporary directory
-    tempDir, err := os.MkdirTemp("", "certs-*")
-    if err != nil {
-        return "", fmt.Errorf("failed to create temp directory: %w", err)
-    }
+	// Create temporary directory
+	tempDir, err := os.MkdirTemp("", "certs-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
 
-    // Store current working directory
-    originalDir, err := os.Getwd()
-    if err != nil {
-        return "", fmt.Errorf("failed to get current directory: %w", err)
-    }
+	// Store current working directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %w", err)
+	}
 
-    // Change to temp directory
-    if err := os.Chdir(tempDir); err != nil {
-        return "", fmt.Errorf("failed to change to temp directory: %w", err)
-    }
+	// Change to temp directory
+	if err := os.Chdir(tempDir); err != nil {
+		return "", fmt.Errorf("failed to change to temp directory: %w", err)
+	}
 
-    // Ensure we change back to original directory when function returns
-    defer os.Chdir(originalDir)
+	// Ensure we change back to original directory when function returns
+	defer os.Chdir(originalDir)
 
-    // Generate wildcard certificate
-    wildcardDomain := "*." + domain
-    cmd := exec.Command("mkcert", wildcardDomain)
-    if err := cmd.Run(); err != nil {
-        return "", fmt.Errorf("failed to generate certificate: %w", err)
-    }
+	// Generate wildcard certificate
+	wildcardDomain := "*." + domain
+	cmd := exec.Command("mkcert", wildcardDomain)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to generate certificate: %w", err)
+	}
 
-    // Generate file names
-    keyFile := fmt.Sprintf("_wildcard.%s-key.pem", domain)
-    certFile := fmt.Sprintf("_wildcard.%s.pem", domain)
+	// Generate file names
+	keyFile := fmt.Sprintf("_wildcard.%s-key.pem", domain)
+	certFile := fmt.Sprintf("_wildcard.%s.pem", domain)
 
-    // Rename files
-    if err := os.Rename(keyFile, "private-key.pem"); err != nil {
-        return "", fmt.Errorf("failed to rename key file: %w", err)
-    }
-    if err := os.Rename(certFile, "full-chain.pem"); err != nil {
-        return "", fmt.Errorf("failed to rename cert file: %w", err)
-    }
+	// Rename files
+	if err := os.Rename(keyFile, "private-key.pem"); err != nil {
+		return "", fmt.Errorf("failed to rename key file: %w", err)
+	}
+	if err := os.Rename(certFile, "full-chain.pem"); err != nil {
+		return "", fmt.Errorf("failed to rename cert file: %w", err)
+	}
 
-    return tempDir, nil
+	return tempDir, nil
 }
 
 func (o *initOptions) run(cmd *cobra.Command, args []string) error {
@@ -190,7 +190,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 
 	// Init shared Caddy if not exists
 	caddyConfig := bitswanConfig + "caddy"
-  caddyCertsDir := caddyConfig + "/certs"
+	caddyCertsDir := caddyConfig + "/certs"
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -255,7 +255,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		// Create certs directory if it doesn't exist
 		if _, err := os.Stat(caddyCertsDir); os.IsNotExist(err) {
 			if err := os.MkdirAll(caddyCertsDir, 0740); err != nil {
-        return fmt.Errorf("failed to create Caddy certs directory: %w", err)
+				return fmt.Errorf("failed to create Caddy certs directory: %w", err)
 			}
 		}
 
@@ -281,10 +281,10 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	inputCertsDir := o.certsDir
 
 	if o.mkCerts {
-    certDir, err := generateWildcardCerts(o.domain)
-    if err != nil {
+		certDir, err := generateWildcardCerts(o.domain)
+		if err != nil {
 			return fmt.Errorf("Error generating certificates: %v\n", err)
-    }
+		}
 		inputCertsDir = certDir
 	}
 
@@ -420,7 +420,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create secrets directory: %w", err)
 	}
 
-	if(!o.noIde) {
+	if !o.noIde {
 		chownCom := exec.Command("sudo", "chown", "-R", "1000:1000", secretsDir)
 		if err := runCommandVerbose(chownCom, o.verbose); err != nil {
 			return fmt.Errorf("failed to change ownership of secrets folder: %w", err)
@@ -428,7 +428,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Change ownership of workspace folder recursively
-	if (!o.noIde) {
+	if !o.noIde {
 		chownCom := exec.Command("sudo", "chown", "-R", "1000:1000", gitopsWorkspace)
 		if err := runCommandVerbose(chownCom, o.verbose); err != nil {
 			return fmt.Errorf("failed to change ownership of workspace folder: %w", err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -505,13 +505,13 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 			panic(fmt.Errorf("Failed to get Bitswan Editor password: %w", err))
 		}
 		fmt.Println("------------BITSWAN EDITOR INFO------------")
-		fmt.Printf("Bitswan Editor URL: https://editor.%s\n", o.domain)
+		fmt.Printf("Bitswan Editor URL: https://%s-editor.%s\n", gitopsName, o.domain)
 		fmt.Printf("Bitswan Editor Password: %s\n", editorPassword)
 	}
 
 	fmt.Println("------------GITOPS INFO------------")
 	fmt.Printf("GitOps ID: %s\n", gitopsName)
-	fmt.Printf("GitOps URL: https://%s\n", o.domain)
+	fmt.Printf("GitOps URL: https://%s-gitops.%s\n", gitopsName, o.domain)
 	fmt.Printf("GitOps Secret: %s\n", token)
 
 	return nil

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -184,7 +184,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 			panic(fmt.Errorf("Failed to write Caddyfile: %w", err))
 		}
 
-		caddyDockerCompose, err := dockercompose.CreateCaddyDockerComposeFile(caddyConfig, o.certsDir, o.domain)
+		caddyDockerCompose, err := dockercompose.CreateCaddyDockerComposeFile(caddyConfig, o.domain)
 		if err != nil {
 			panic(fmt.Errorf("Failed to create Caddy docker-compose file: %w", err))
 		}
@@ -413,7 +413,6 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		gitopsName,
 		gitopsImage,
 		bitswanEditorImage,
-		o.certsDir,
 		o.domain,
 		o.noIde,
 	)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,6 +21,7 @@ type initOptions struct {
 	domain     string
 	certsDir   string
 	verbose   bool
+	mkCerts    bool
 	noIde      bool
 	gitopsImage string
 	editorImage string
@@ -56,6 +57,7 @@ func newInitCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.certsDir, "certs-dir", "", "The directory where the certificates are located")
 	cmd.Flags().BoolVar(&o.noIde, "no-ide", false, "Do not start Bitswan Editor")
 	cmd.Flags().BoolVarP(&o.verbose, "verbose", "v", false, "Verbose output")
+	cmd.Flags().BoolVar(&o.mkCerts, "mkcerts", false, "Automatically generate local certificates using the mkcerts utility")
 	cmd.Flags().StringVar(&o.gitopsImage, "gitops-image", "", "Custom image for the gitops")
 	cmd.Flags().StringVar(&o.editorImage, "editor-image", "", "Custom image for the editor")
 
@@ -109,6 +111,49 @@ func runCommandVerbose(cmd *exec.Cmd, verbose bool) (error) {
 		err = cmd.Run()
 	}
 	return err
+}
+
+func generateWildcardCerts(domain string) (string, error) {
+    // Create temporary directory
+    tempDir, err := os.MkdirTemp("", "certs-*")
+    if err != nil {
+        return "", fmt.Errorf("failed to create temp directory: %w", err)
+    }
+
+    // Store current working directory
+    originalDir, err := os.Getwd()
+    if err != nil {
+        return "", fmt.Errorf("failed to get current directory: %w", err)
+    }
+
+    // Change to temp directory
+    if err := os.Chdir(tempDir); err != nil {
+        return "", fmt.Errorf("failed to change to temp directory: %w", err)
+    }
+
+    // Ensure we change back to original directory when function returns
+    defer os.Chdir(originalDir)
+
+    // Generate wildcard certificate
+    wildcardDomain := "*." + domain
+    cmd := exec.Command("mkcert", wildcardDomain)
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("failed to generate certificate: %w", err)
+    }
+
+    // Generate file names
+    keyFile := fmt.Sprintf("_wildcard.%s-key.pem", domain)
+    certFile := fmt.Sprintf("_wildcard.%s.pem", domain)
+
+    // Rename files
+    if err := os.Rename(keyFile, "private-key.pem"); err != nil {
+        return "", fmt.Errorf("failed to rename key file: %w", err)
+    }
+    if err := os.Rename(certFile, "full-chain.pem"); err != nil {
+        return "", fmt.Errorf("failed to rename cert file: %w", err)
+    }
+
+    return tempDir, nil
 }
 
 func (o *initOptions) run(cmd *cobra.Command, args []string) error {
@@ -233,7 +278,18 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		fmt.Println("A running instance of Caddy with admin found")
 	}
 
-	if o.certsDir != "" {
+	inputCertsDir := o.certsDir
+
+	if o.mkCerts {
+    certDir, err := generateWildcardCerts(o.domain)
+    if err != nil {
+			return fmt.Errorf("Error generating certificates: %v\n", err)
+    }
+		inputCertsDir = certDir
+	}
+
+	if inputCertsDir != "" {
+		fmt.Println("Installing certs from", inputCertsDir)
 		caddyCertsDir := caddyConfig + "/certs"
 		if _, err := os.Stat(caddyCertsDir); os.IsNotExist(err) {
 			if err := os.MkdirAll(caddyCertsDir, 0755); err != nil {
@@ -248,7 +304,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		certs, err := os.ReadDir(o.certsDir)
+		certs, err := os.ReadDir(inputCertsDir)
 		if err != nil {
 			panic(fmt.Errorf("Failed to read certs directory: %w", err))
 		}
@@ -258,7 +314,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 				continue
 			}
 
-			certPath := o.certsDir + "/" + cert.Name()
+			certPath := inputCertsDir + "/" + cert.Name()
 			newCertPath := certsDir + "/" + cert.Name()
 
 			bytes, err := os.ReadFile(certPath)
@@ -403,7 +459,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to create deployment directory: %w", err)
 	}
 
-	err = caddyapi.AddCaddyRecords(gitopsName, o.domain, o.certsDir != "", o.noIde)
+	err = caddyapi.AddCaddyRecords(gitopsName, o.domain, inputCertsDir != "", o.noIde)
 	if err != nil {
 		panic(fmt.Errorf("Failed to add Caddy records: %w", err))
 	}

--- a/internal/caddyapi/caddyapi.go
+++ b/internal/caddyapi/caddyapi.go
@@ -56,7 +56,7 @@ func AddCaddyRecords(gitopsName, domain string, certs, noIde bool) error {
 
 	// GitOps route
 	routes = append(routes, Route{
-		Match: []Match{{Host: []string{domain}}},
+		Match: []Match{{Host: []string{fmt.Sprintf("%s-gitops.%s", gitopsName, domain)}}},
 		Handle: []Handle{{Handler: "subroute", Routes: []Route{
 			{
 				Handle: []Handle{{Handler: "reverse_proxy", Upstreams: []Upstream{
@@ -72,7 +72,7 @@ func AddCaddyRecords(gitopsName, domain string, certs, noIde bool) error {
 		routes = append(routes, Route{
 			Match: []Match{
 				{
-					Host: []string{fmt.Sprintf("editor.%s", domain)},
+					Host: []string{fmt.Sprintf("%s-editor.%s", gitopsName, domain)},
 				},
 			},
 			Handle: []Handle{

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -19,7 +19,7 @@ const (
 	Linux
 )
 
-func CreateDockerComposeFile(gitopsPath, gitopsName, gitopsImage, bitswanEditorImage, certsPath, domain string, noIde bool) (string, string, error) {
+func CreateDockerComposeFile(gitopsPath, gitopsName, gitopsImage, bitswanEditorImage, domain string, noIde bool) (string, string, error) {
 	sshDir := os.Getenv("HOME") + "/.ssh"
 	gitConfig := os.Getenv("HOME") + "/.gitconfig"
 
@@ -131,7 +131,7 @@ func CreateDockerComposeFile(gitopsPath, gitopsName, gitopsImage, bitswanEditorI
 	return buf.String(), gitopsSecretToken, nil
 }
 
-func CreateCaddyDockerComposeFile(caddyPath, certsPath, domain string) (string, error) {
+func CreateCaddyDockerComposeFile(caddyPath, domain string) (string, error) {
 	caddyVolumes := []string{
 		caddyPath + "/Caddyfile:/etc/caddy/Caddyfile",
 		caddyPath + "/data:/data",

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -19,7 +19,7 @@ const (
 	Linux
 )
 
-func CreateDockerComposeFile(gitopsPath, gitopsName, latestGitopsVersion, latestBitswanEditorVersion, certsPath, domain string, noIde bool) (string, string, error) {
+func CreateDockerComposeFile(gitopsPath, gitopsName, gitopsImage, bitswanEditorImage, certsPath, domain string, noIde bool) (string, string, error) {
 	sshDir := os.Getenv("HOME") + "/.ssh"
 	gitConfig := os.Getenv("HOME") + "/.gitconfig"
 
@@ -39,7 +39,7 @@ func CreateDockerComposeFile(gitopsPath, gitopsName, latestGitopsVersion, latest
 	gitopsSecretToken := uniuri.NewLen(64)
 
 	gitopsService := map[string]interface{}{
-		"image":    "bitswan/gitops:" + latestGitopsVersion,
+		"image":    gitopsImage,
 		"restart":  "always",
 		"networks": []string{"bitswan_network"},
 		"volumes": []string{
@@ -97,7 +97,7 @@ func CreateDockerComposeFile(gitopsPath, gitopsName, latestGitopsVersion, latest
 
 	if !noIde {
 		bitswanEditor := map[string]interface{}{
-			"image":    "bitswan/bitswan-editor:" + latestBitswanEditorVersion,
+			"image":    bitswanEditorImage,
 			"restart":  "always",
 			"networks": []string{"bitswan_network"},
 			"environment": []string{
@@ -172,12 +172,11 @@ func CreateCaddyDockerComposeFile(caddyPath, certsPath, domain string) (string, 
 	return buf.String(), nil
 }
 
-
 type EditorConfig struct {
 	BindAddress string `yaml:"bind-addr"`
-	Auth string `yaml:"auth"`
-	Password string `yaml:"password"`
-	Cert bool `yaml:"cert"`
+	Auth        string `yaml:"auth"`
+	Password    string `yaml:"password"`
+	Cert        bool   `yaml:"cert"`
 }
 
 func GetEditorPassword(projectName, gitopsName string) (string, error) {

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -53,7 +53,7 @@ func CreateDockerComposeFile(gitopsPath, gitopsName, gitopsImage, bitswanEditorI
 			"BITSWAN_GITOPS_DIR_HOST=" + gitopsPath,
 			"BITSWAN_GITOPS_ID=" + gitopsName,
 			"BITSWAN_GITOPS_SECRET=" + gitopsSecretToken,
-			"BITSWAN_GITOPS_DOMAIN=" + domain,
+			"BITSWAN_GITOPS_DOMAIN=" + fmt.Sprintf("%s-gitops.%s", gitopsName, domain),
 		},
 	}
 


### PR DESCRIPTION
This adds a new flag for automatically `--mkcerts` that automatically generates local certs when installing the gitops locally.