### PR TITLE
added possibility to change caddy ingress base url using BITSWAN_CADDY_HOST env var, default is localhost:2019

### DIFF
--- a/internal/caddyapi/caddyapi.go
+++ b/internal/caddyapi/caddyapi.go
@@ -57,12 +57,25 @@ type TLSFileLoad struct {
 
 // getCaddyBaseURL returns the base URL for the Caddy API, preferring
 // the BITSWAN_CADDY_HOST environment variable if set, otherwise defaulting
-// to http://localhost:2019
+// to http://localhost:2019. It also normalizes the value by ensuring a scheme
+// and stripping any trailing slash.
 func getCaddyBaseURL() string {
-    if host := os.Getenv("BITSWAN_CADDY_HOST"); host != "" {
-        return host
+    host := strings.TrimSpace(os.Getenv("BITSWAN_CADDY_HOST"))
+    if host == "" {
+        return "http://localhost:2019"
     }
-    return "http://localhost:2019"
+
+    // Prepend default scheme if missing
+    if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+        host = "http://" + host
+    }
+
+    // Strip trailing slash if present
+    if strings.HasSuffix(host, "/") {
+        host = strings.TrimRight(host, "/")
+    }
+
+    return host
 }
 
 func RegisterServiceWithCaddy(serviceName, workspaceName, domain, upstream string) error {


### PR DESCRIPTION
This pull request refactors the way the Caddy API base URL is determined in `internal/caddyapi/caddyapi.go`. Instead of hardcoding `http://localhost:2019` throughout the code, it introduces a helper function that checks for the `BITSWAN_CADDY_HOST` environment variable, allowing the base URL to be configured dynamically. All Caddy API calls now use this function, improving flexibility and portability.

**Configuration improvements:**

* Added a `getCaddyBaseURL` function that returns the Caddy API base URL, preferring the `BITSWAN_CADDY_HOST` environment variable if set, otherwise defaulting to `http://localhost:2019`.

**Refactoring API usage:**

* Updated all hardcoded Caddy API URLs in functions such as `UnregisterCaddyService`, `InstallTLSCerts`, `InitCaddy`, `DeleteCaddyRecords`, `AddRoute`, `RemoveRoute`, `ListRoutes`, and `InstallTLSCertsForHostname` to use `getCaddyBaseURL` for constructing the base URL.