### PR TITLE
fix: improve installation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ curl -L "https://github.com/bitswan-space/bitswan-automation-server/releases/dow
 Move the binary to a directory in your PATH
 
 ```
-sudo mv bitswan /usr/local/bin/
+sudo mv bitswan-automation-server-<your-version> /usr/local/bin/bitswan
 ```
 
 Alternatively, if you don't have sudo access or prefer a local installation:
 
 ```
 mkdir -p ~/bin
-mv bitswan ~/bin/
+mv bitswan-automation-server-<your-version> ~/bin/
 
 #Add to PATH if using ~/bin (add this to your ~/.bashrc or ~/.zshrc)
 export PATH="$HOME/bin:$PATH"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates README install steps to move `bitswan-automation-server-<your-version>` to `bitswan` in PATH locations.
> 
> - **Docs (README)**:
>   - **Installation**:
>     - Update move commands to use `bitswan-automation-server-<your-version>` and install as `bitswan` in `/usr/local/bin` or `~/bin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a00ab2d964ab4b926ffe8181a724481f52945211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->