### PR TITLE
feat: add disconnect-from-aoc command and prevent double registration

### DIFF
--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -32,6 +32,7 @@ func newDisconnectFromAOCCmd() *cobra.Command {
 			fmt.Println("  - Remove OAuth config files from all workspaces")
 			fmt.Println("  - Clear MQTT connection settings from workspace metadata")
 			fmt.Println("  - Disconnect the MQTT connection")
+			fmt.Println("  - Regenerate docker-compose files and restart workspace services")
 			fmt.Println()
 			fmt.Println("Your workspaces and their data will NOT be deleted.")
 			fmt.Println()

--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -4,13 +4,11 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/config"
 	"github.com/bitswan-space/bitswan-workspaces/internal/daemon"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 func newDisconnectFromAOCCmd() *cobra.Command {
@@ -52,34 +50,15 @@ func newDisconnectFromAOCCmd() *cobra.Command {
 
 			fmt.Println()
 
-			// 1. Disconnect MQTT via daemon
-			fmt.Println("Disconnecting MQTT connection...")
 			client, err := daemon.NewClient()
 			if err != nil {
-				fmt.Printf("Warning: Could not connect to daemon: %v\n", err)
-				fmt.Println("MQTT will be disconnected when the daemon restarts.")
-			} else {
-				if err := client.DisconnectMQTT(); err != nil {
-					fmt.Printf("Warning: Failed to disconnect MQTT: %v\n", err)
-				} else {
-					fmt.Println("MQTT connection disconnected.")
-				}
+				return fmt.Errorf("failed to create daemon client (daemon may not be running): %w", err)
 			}
 
-			// 2. Clean up workspace metadata and OAuth configs
-			fmt.Println("Cleaning up workspace configurations...")
-			if err := cleanupWorkspaceAOCConfig(); err != nil {
-				fmt.Printf("Warning: Failed to clean up some workspace configs: %v\n", err)
+			if err := client.DisconnectFromAOC(); err != nil {
+				return err
 			}
 
-			// 3. Clear AOC settings from the main config
-			fmt.Println("Removing AOC credentials...")
-			if err := cfg.ClearAOCSettings(); err != nil {
-				return fmt.Errorf("failed to clear AOC settings: %w", err)
-			}
-
-			fmt.Println()
-			fmt.Println("Successfully disconnected from AOC.")
 			fmt.Println("You can register with a new AOC instance using 'bitswan register'.")
 
 			return nil
@@ -87,80 +66,4 @@ func newDisconnectFromAOCCmd() *cobra.Command {
 	}
 
 	return cmd
-}
-
-// cleanupWorkspaceAOCConfig removes OAuth config files and clears MQTT metadata from all workspaces
-func cleanupWorkspaceAOCConfig() error {
-	homeDir, err := config.GetRealUserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
-	}
-
-	workspacesDir := filepath.Join(homeDir, ".config", "bitswan", "workspaces")
-
-	entries, err := os.ReadDir(workspacesDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to read workspaces directory: %w", err)
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		workspaceName := entry.Name()
-		workspacePath := filepath.Join(workspacesDir, workspaceName)
-
-		// Remove oauth-config.yaml
-		oauthConfigPath := filepath.Join(workspacePath, "oauth-config.yaml")
-		if _, err := os.Stat(oauthConfigPath); err == nil {
-			if err := os.Remove(oauthConfigPath); err != nil {
-				fmt.Printf("  Warning: Failed to remove %s: %v\n", oauthConfigPath, err)
-			} else {
-				fmt.Printf("  Removed OAuth config for workspace '%s'\n", workspaceName)
-			}
-		}
-
-		// Clear MQTT and workspace_id fields from metadata.yaml
-		metadataPath := filepath.Join(workspacePath, "metadata.yaml")
-		if err := clearWorkspaceAOCMetadata(metadataPath, workspaceName); err != nil {
-			fmt.Printf("  Warning: Failed to update metadata for workspace '%s': %v\n", workspaceName, err)
-		}
-	}
-
-	return nil
-}
-
-// clearWorkspaceAOCMetadata clears AOC-related fields from a workspace's metadata.yaml
-func clearWorkspaceAOCMetadata(metadataPath, workspaceName string) error {
-	data, err := os.ReadFile(metadataPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	var metadata config.WorkspaceMetadata
-	if err := yaml.Unmarshal(data, &metadata); err != nil {
-		return fmt.Errorf("failed to parse metadata: %w", err)
-	}
-
-	// Clear AOC-related fields
-	metadata.WorkspaceId = nil
-	metadata.MqttUsername = nil
-	metadata.MqttPassword = nil
-	metadata.MqttBroker = nil
-	metadata.MqttPort = nil
-	metadata.MqttTopic = nil
-
-	if err := metadata.SaveToFile(metadataPath); err != nil {
-		return fmt.Errorf("failed to save metadata: %w", err)
-	}
-
-	fmt.Printf("  Cleared AOC metadata for workspace '%s'\n", workspaceName)
-	return nil
 }

--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/config"
+	"github.com/bitswan-space/bitswan-workspaces/internal/daemon"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func newDisconnectFromAOCCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "disconnect-from-aoc",
+		Short:        "Disconnect automation server from AOC",
+		Long:         "Disconnect this automation server from its current AOC instance. This removes AOC credentials, OAuth config, and MQTT settings from workspace metadata. Workspaces and their data are preserved.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check if actually registered
+			cfg := config.NewAutomationServerConfig()
+			settings, err := cfg.GetAutomationOperationsCenterSettings()
+			if err != nil || settings.AccessToken == "" {
+				return fmt.Errorf("this automation server is not registered to any AOC instance")
+			}
+
+			fmt.Printf("This automation server is registered to AOC at %s (server ID: %s).\n\n", settings.AOCUrl, settings.AutomationServerId)
+			fmt.Println("Disconnecting will:")
+			fmt.Println("  - Remove AOC credentials from the server config")
+			fmt.Println("  - Remove OAuth config files from all workspaces")
+			fmt.Println("  - Clear MQTT connection settings from workspace metadata")
+			fmt.Println("  - Disconnect the MQTT connection")
+			fmt.Println()
+			fmt.Println("Your workspaces and their data will NOT be deleted.")
+			fmt.Println()
+			fmt.Print("Type 'yes' to confirm: ")
+
+			reader := bufio.NewReader(os.Stdin)
+			confirmation, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("failed to read confirmation: %w", err)
+			}
+
+			if strings.TrimSpace(confirmation) != "yes" {
+				fmt.Println("Disconnect cancelled.")
+				return nil
+			}
+
+			fmt.Println()
+
+			// 1. Disconnect MQTT via daemon
+			fmt.Println("Disconnecting MQTT connection...")
+			client, err := daemon.NewClient()
+			if err != nil {
+				fmt.Printf("Warning: Could not connect to daemon: %v\n", err)
+				fmt.Println("MQTT will be disconnected when the daemon restarts.")
+			} else {
+				if err := client.DisconnectMQTT(); err != nil {
+					fmt.Printf("Warning: Failed to disconnect MQTT: %v\n", err)
+				} else {
+					fmt.Println("MQTT connection disconnected.")
+				}
+			}
+
+			// 2. Clean up workspace metadata and OAuth configs
+			fmt.Println("Cleaning up workspace configurations...")
+			if err := cleanupWorkspaceAOCConfig(); err != nil {
+				fmt.Printf("Warning: Failed to clean up some workspace configs: %v\n", err)
+			}
+
+			// 3. Clear AOC settings from the main config
+			fmt.Println("Removing AOC credentials...")
+			if err := cfg.ClearAOCSettings(); err != nil {
+				return fmt.Errorf("failed to clear AOC settings: %w", err)
+			}
+
+			fmt.Println()
+			fmt.Println("Successfully disconnected from AOC.")
+			fmt.Println("You can register with a new AOC instance using 'bitswan register'.")
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+// cleanupWorkspaceAOCConfig removes OAuth config files and clears MQTT metadata from all workspaces
+func cleanupWorkspaceAOCConfig() error {
+	homeDir, err := config.GetRealUserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	workspacesDir := filepath.Join(homeDir, ".config", "bitswan", "workspaces")
+
+	entries, err := os.ReadDir(workspacesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read workspaces directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		workspaceName := entry.Name()
+		workspacePath := filepath.Join(workspacesDir, workspaceName)
+
+		// Remove oauth-config.yaml
+		oauthConfigPath := filepath.Join(workspacePath, "oauth-config.yaml")
+		if _, err := os.Stat(oauthConfigPath); err == nil {
+			if err := os.Remove(oauthConfigPath); err != nil {
+				fmt.Printf("  Warning: Failed to remove %s: %v\n", oauthConfigPath, err)
+			} else {
+				fmt.Printf("  Removed OAuth config for workspace '%s'\n", workspaceName)
+			}
+		}
+
+		// Clear MQTT and workspace_id fields from metadata.yaml
+		metadataPath := filepath.Join(workspacePath, "metadata.yaml")
+		if err := clearWorkspaceAOCMetadata(metadataPath, workspaceName); err != nil {
+			fmt.Printf("  Warning: Failed to update metadata for workspace '%s': %v\n", workspaceName, err)
+		}
+	}
+
+	return nil
+}
+
+// clearWorkspaceAOCMetadata clears AOC-related fields from a workspace's metadata.yaml
+func clearWorkspaceAOCMetadata(metadataPath, workspaceName string) error {
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var metadata config.WorkspaceMetadata
+	if err := yaml.Unmarshal(data, &metadata); err != nil {
+		return fmt.Errorf("failed to parse metadata: %w", err)
+	}
+
+	// Clear AOC-related fields
+	metadata.WorkspaceId = nil
+	metadata.MqttUsername = nil
+	metadata.MqttPassword = nil
+	metadata.MqttBroker = nil
+	metadata.MqttPort = nil
+	metadata.MqttTopic = nil
+
+	if err := metadata.SaveToFile(metadataPath); err != nil {
+		return fmt.Errorf("failed to save metadata: %w", err)
+	}
+
+	fmt.Printf("  Cleared AOC metadata for workspace '%s'\n", workspaceName)
+	return nil
+}

--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -15,7 +15,7 @@ func newDisconnectFromAOCCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "disconnect-from-aoc",
 		Short:        "Disconnect automation server from AOC",
-		Long:         "Disconnect this automation server from its current AOC instance. This removes AOC credentials, OAuth config, and MQTT settings from workspace metadata. Workspaces and their data are preserved.",
+		Long:         "Disconnect this automation server from its current AOC instance. This removes AOC credentials and restarts workspace services. Workspaces and their data are preserved.",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -26,14 +26,8 @@ func newDisconnectFromAOCCmd() *cobra.Command {
 				return fmt.Errorf("this automation server is not registered to any AOC instance")
 			}
 
-			fmt.Printf("This automation server is registered to AOC at %s (server ID: %s).\n\n", settings.AOCUrl, settings.AutomationServerId)
-			fmt.Println("Disconnecting will:")
-			fmt.Println("  - Remove AOC credentials from the server config")
-			fmt.Println("  - Remove OAuth config files from all workspaces")
-			fmt.Println("  - Clear MQTT connection settings from workspace metadata")
-			fmt.Println("  - Disconnect the MQTT connection")
-			fmt.Println("  - Regenerate docker-compose files and restart workspace services")
-			fmt.Println()
+			fmt.Printf("This automation server is registered to AOC at %s.\n\n", settings.AOCUrl)
+			fmt.Println("Disconnecting will remove the AOC connection and restart workspace services.")
 			fmt.Println("Your workspaces and their data will NOT be deleted.")
 			fmt.Println()
 			fmt.Print("Type 'yes' to confirm: ")

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/aoc"
+	"github.com/bitswan-space/bitswan-workspaces/internal/config"
 	"github.com/bitswan-space/bitswan-workspaces/internal/daemon"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,17 @@ func newRegisterCmd() *cobra.Command {
 
 			if automationServerId == "" {
 				return fmt.Errorf("automation server ID is required. Use --server-id flag to provide the automation server ID from the web interface")
+			}
+
+			// Check if already registered to an AOC instance
+			cfg := config.NewAutomationServerConfig()
+			if settings, err := cfg.GetAutomationOperationsCenterSettings(); err == nil && settings.AccessToken != "" {
+				return fmt.Errorf(
+					"this automation server is already registered to an AOC instance at %s (server ID: %s).\n"+
+						"To register with a different AOC instance, first disconnect using:\n\n"+
+						"  bitswan disconnect-from-aoc",
+					settings.AOCUrl, settings.AutomationServerId,
+				)
 			}
 
 			// Create AOC client with OTP

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,7 @@ func newRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newVersionCmd(version))                                    // version subcommand
 	cmd.AddCommand(newWorkspaceCmd())                                         // workspace subcommand
 	cmd.AddCommand(newRegisterCmd())                                          // register subcommand
+	cmd.AddCommand(newDisconnectFromAOCCmd())                                 // disconnect-from-aoc subcommand
 	cmd.AddCommand(ingress.NewIngressCmd())                                   // ingress subcommand
 	cmd.AddCommand(caddy.NewCaddyCmd())                                       // caddy subcommand (deprecated)
 	cmd.AddCommand(certauthority.NewCertAuthorityCmd())                       // certificate authority subcommand

--- a/internal/config/automationserverconfig.go
+++ b/internal/config/automationserverconfig.go
@@ -210,6 +210,17 @@ func (m *AutomationServerConfig) ConfigExists() bool {
 	return tomlExists == nil
 }
 
+// ClearAOCSettings removes the AOC connection settings while preserving other config
+func (m *AutomationServerConfig) ClearAOCSettings() error {
+	config, err := m.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	config.AutomationOperationsCenter = AutomationOperationsCenterSettings{}
+	return m.SaveConfig(config)
+}
+
 // GetConfigPath returns the path to the primary TOML config file
 func (m *AutomationServerConfig) GetConfigPath() string {
 	return filepath.Join(m.configDir, "automation_server_config.toml")

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -959,25 +959,33 @@ func (c *Client) ReconnectMQTT() error {
 	return nil
 }
 
-// DisconnectMQTT disconnects the MQTT connection without reinitializing.
-func (c *Client) DisconnectMQTT() error {
-	req, err := http.NewRequest("POST", "http://unix/mqtt/disconnect", nil)
+// DisconnectFromAOC tells the daemon to disconnect from AOC, cleaning up MQTT, OAuth, and workspace metadata.
+func (c *Client) DisconnectFromAOC() error {
+	req, err := http.NewRequest("POST", "http://unix/workspace/disconnect-from-aoc", nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := c.doRequest(req)
+	resp, err := c.doStreamingRequest(req)
 	if err != nil {
 		return fmt.Errorf("failed to connect to daemon: %w", err)
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("authentication failed: invalid or missing token")
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("MQTT disconnect failed: %s", string(body))
+		var errResp ErrorResponse
+		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+			return fmt.Errorf("%s", errResp.Error)
+		}
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
 
-	return nil
+	_, err = c.streamLogs(resp.Body, os.Stdout)
+	return err
 }
 
 // WorkspaceRemove runs `bitswan workspace remove ...` via the daemon with NDJSON streaming.

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -959,6 +959,27 @@ func (c *Client) ReconnectMQTT() error {
 	return nil
 }
 
+// DisconnectMQTT disconnects the MQTT connection without reinitializing.
+func (c *Client) DisconnectMQTT() error {
+	req, err := http.NewRequest("POST", "http://unix/mqtt/disconnect", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("MQTT disconnect failed: %s", string(body))
+	}
+
+	return nil
+}
+
 // WorkspaceRemove runs `bitswan workspace remove ...` via the daemon with NDJSON streaming.
 func (c *Client) WorkspaceRemove(workspaceName string) error {
 	bodyBytes, err := json.Marshal(WorkspaceRemoveRequest{Workspace: workspaceName})

--- a/internal/daemon/mqtt_init.go
+++ b/internal/daemon/mqtt_init.go
@@ -164,6 +164,26 @@ func (s *Server) handleMQTTReinitialize(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// handleMQTTDisconnect handles POST /mqtt/disconnect
+// Disconnects the MQTT connection without reinitializing. Used when disconnecting from AOC.
+func (s *Server) handleMQTTDisconnect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error": "method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	fmt.Println("MQTT disconnect requested via API")
+
+	publisher := GetMQTTPublisher()
+	publisher.Disconnect()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "ok",
+		"message": "MQTT publisher disconnected",
+	})
+}
+
 // monitorMQTTConnection continuously monitors the MQTT connection and attempts to reconnect if it fails
 // This provides automatic self-healing for the MQTT connection
 func monitorMQTTConnection(server *Server) {

--- a/internal/daemon/mqtt_init.go
+++ b/internal/daemon/mqtt_init.go
@@ -5,10 +5,38 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/aoc"
 )
+
+// mqttMonitorStop is used to signal the MQTT monitor goroutine to stop.
+var (
+	mqttMonitorStop chan struct{}
+	mqttMonitorMu   sync.Mutex
+)
+
+// stopMQTTMonitor signals the background MQTT monitor to stop.
+func stopMQTTMonitor() {
+	mqttMonitorMu.Lock()
+	defer mqttMonitorMu.Unlock()
+	if mqttMonitorStop != nil {
+		close(mqttMonitorStop)
+		mqttMonitorStop = nil
+	}
+}
+
+// startMQTTMonitor starts a new background MQTT monitor, stopping any existing one.
+func startMQTTMonitor(server *Server) {
+	mqttMonitorMu.Lock()
+	defer mqttMonitorMu.Unlock()
+	if mqttMonitorStop != nil {
+		close(mqttMonitorStop)
+	}
+	mqttMonitorStop = make(chan struct{})
+	go monitorMQTTConnection(server, mqttMonitorStop)
+}
 
 // initializeMQTTPublisher initializes the MQTT publisher if AOC is configured
 // This function is non-blocking and will retry on failure
@@ -33,7 +61,7 @@ func initializeMQTTPublisherWithServer(server *Server) error {
 			if initialized {
 				// Successfully initialized!
 				fmt.Println("Starting background health monitor for MQTT connection...")
-				go monitorMQTTConnection(server)
+				startMQTTMonitor(server)
 				return
 			}
 
@@ -51,7 +79,7 @@ func initializeMQTTPublisherWithServer(server *Server) error {
 				fmt.Printf("MQTT publisher initialization failed after %d attempts: %v. Starting background reconnection monitor...\n",
 					maxRetries, err)
 				// Start background reconnection monitor even if initial attempts failed
-				go monitorMQTTConnection(server)
+				startMQTTMonitor(server)
 			}
 		}
 	}()
@@ -136,7 +164,7 @@ func (s *Server) handleMQTTReinitialize(w http.ResponseWriter, r *http.Request) 
 	initialized, err := tryInitializeMQTTPublisher(s)
 	if initialized {
 		// Start a new health monitor
-		go monitorMQTTConnection(s)
+		startMQTTMonitor(s)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{
 			"status":  "ok",
@@ -164,32 +192,34 @@ func (s *Server) handleMQTTReinitialize(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// monitorMQTTConnection continuously monitors the MQTT connection and attempts to reconnect if it fails
-// This provides automatic self-healing for the MQTT connection
-func monitorMQTTConnection(server *Server) {
+// monitorMQTTConnection continuously monitors the MQTT connection and attempts to reconnect if it fails.
+// Exits when stop is closed or when AOC is no longer configured.
+func monitorMQTTConnection(server *Server, stop chan struct{}) {
 	checkInterval := 30 * time.Second
 	reconnectDelay := 10 * time.Second
 
-	fmt.Println("MQTT connection monitor started (checking every 30 seconds)")
-
 	for {
-		time.Sleep(checkInterval)
+		select {
+		case <-stop:
+			return
+		case <-time.After(checkInterval):
+		}
 
 		publisher := GetMQTTPublisher()
 		if !publisher.IsConnected() {
-			fmt.Println("MQTT connection lost, attempting to reconnect...")
-
-			// Try to reinitialize the connection
 			initialized, err := tryInitializeMQTTPublisher(server)
 			if initialized {
-				fmt.Println("MQTT connection successfully restored!")
-			} else if err != nil {
-				fmt.Printf("MQTT reconnection failed: %v. Will retry in %v...\n", err, checkInterval)
-			}
-
-			// If we failed, wait before the next automatic check
-			if !initialized && err != nil {
-				time.Sleep(reconnectDelay)
+				fmt.Println("MQTT connection restored.")
+			} else if err == nil {
+				// AOC not configured — stop monitoring
+				return
+			} else {
+				fmt.Printf("MQTT reconnection failed: %v\n", err)
+				select {
+				case <-stop:
+					return
+				case <-time.After(reconnectDelay):
+				}
 			}
 		}
 	}

--- a/internal/daemon/mqtt_init.go
+++ b/internal/daemon/mqtt_init.go
@@ -164,26 +164,6 @@ func (s *Server) handleMQTTReinitialize(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// handleMQTTDisconnect handles POST /mqtt/disconnect
-// Disconnects the MQTT connection without reinitializing. Used when disconnecting from AOC.
-func (s *Server) handleMQTTDisconnect(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, `{"error": "method not allowed"}`, http.StatusMethodNotAllowed)
-		return
-	}
-
-	fmt.Println("MQTT disconnect requested via API")
-
-	publisher := GetMQTTPublisher()
-	publisher.Disconnect()
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{
-		"status":  "ok",
-		"message": "MQTT publisher disconnected",
-	})
-}
-
 // monitorMQTTConnection continuously monitors the MQTT connection and attempts to reconnect if it fails
 // This provides automatic self-healing for the MQTT connection
 func monitorMQTTConnection(server *Server) {

--- a/internal/daemon/permissions.go
+++ b/internal/daemon/permissions.go
@@ -1,0 +1,20 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// chownRecursive sets ownership of path to 1000:1000 recursively.
+// The daemon runs as root but workspace files must be owned by user 1000.
+func chownRecursive(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	cmd := exec.Command("chown", "-R", "1000:1000", path)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("chown %s: %w (%s)", path, err, string(output))
+	}
+	return nil
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -144,6 +144,7 @@ func (s *Server) setupRoutes() *http.ServeMux {
 
 	// MQTT endpoints (authenticated)
 	mux.HandleFunc("/mqtt/reinitialize", s.authMiddleware(s.handleMQTTReinitialize))
+	mux.HandleFunc("/mqtt/disconnect", s.authMiddleware(s.handleMQTTDisconnect))
 
 	// Job endpoints for interactive operations (authenticated)
 	mux.HandleFunc("/jobs", s.authMiddleware(s.handleJobs))

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -144,7 +144,6 @@ func (s *Server) setupRoutes() *http.ServeMux {
 
 	// MQTT endpoints (authenticated)
 	mux.HandleFunc("/mqtt/reinitialize", s.authMiddleware(s.handleMQTTReinitialize))
-	mux.HandleFunc("/mqtt/disconnect", s.authMiddleware(s.handleMQTTDisconnect))
 
 	// Job endpoints for interactive operations (authenticated)
 	mux.HandleFunc("/jobs", s.authMiddleware(s.handleJobs))

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -64,6 +64,8 @@ func (s *Server) handleWorkspace(w http.ResponseWriter, r *http.Request) {
 		s.handleWorkspaceSync(w, r)
 	case path == "connect-to-aoc":
 		s.handleWorkspaceConnectToAOC(w, r)
+	case path == "disconnect-from-aoc":
+		s.handleWorkspaceDisconnectFromAOC(w, r)
 	case path == "start":
 		s.handleWorkspaceStart(w, r)
 	case path == "stop":
@@ -519,6 +521,72 @@ func (s *Server) handleWorkspaceConnectToAOC(w http.ResponseWriter, r *http.Requ
 
 	if err != nil {
 		WriteLogEntry(w, "error", fmt.Sprintf("Operation failed: %v", err))
+	}
+}
+
+// handleWorkspaceDisconnectFromAOC handles POST /workspace/disconnect-from-aoc
+func (s *Server) handleWorkspaceDisconnectFromAOC(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Stream logs (NDJSON)
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	// Redirect stdout to stream logs
+	stdoutMutex.Lock()
+	oldStdout := os.Stdout
+	rPipe, wPipe, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		stdoutMutex.Unlock()
+		WriteLogEntry(w, "error", fmt.Sprintf("Failed to create pipe: %v", pipeErr))
+		return
+	}
+
+	os.Stdout = wPipe
+	stdoutMutex.Unlock()
+
+	defer func() {
+		stdoutMutex.Lock()
+		os.Stdout = oldStdout
+		stdoutMutex.Unlock()
+		rPipe.Close()
+		wPipe.Close()
+	}()
+
+	logWriter := NewLogStreamWriter(w, "info")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := rPipe.Read(buf)
+			if n > 0 {
+				logWriter.Write(buf[:n])
+			}
+			if readErr == io.EOF {
+				break
+			}
+			if readErr != nil {
+				WriteLogEntry(w, "error", fmt.Sprintf("Error reading from pipe: %v", readErr))
+				break
+			}
+		}
+	}()
+
+	// Run the disconnect logic
+	disconnectErr := s.runDisconnectFromAOC()
+	wPipe.Close()
+	wg.Wait()
+
+	if disconnectErr != nil {
+		WriteLogEntry(w, "error", fmt.Sprintf("Operation failed: %v", disconnectErr))
 	}
 }
 

--- a/internal/daemon/workspace_disconnect_from_aoc.go
+++ b/internal/daemon/workspace_disconnect_from_aoc.go
@@ -1,0 +1,106 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// runDisconnectFromAOC disconnects from AOC by cleaning up all AOC-related config
+func (s *Server) runDisconnectFromAOC() error {
+	// 1. Disconnect MQTT
+	fmt.Println("Disconnecting MQTT connection...")
+	publisher := GetMQTTPublisher()
+	publisher.Disconnect()
+	fmt.Println("MQTT connection disconnected.")
+
+	// 2. Clean up workspace metadata and OAuth configs
+	fmt.Println("Cleaning up workspace configurations...")
+	if err := cleanupWorkspaceAOCConfig(); err != nil {
+		fmt.Printf("Warning: Failed to clean up some workspace configs: %v\n", err)
+	}
+
+	// 3. Clear AOC settings from the main config
+	fmt.Println("Removing AOC credentials...")
+	cfg := config.NewAutomationServerConfig()
+	if err := cfg.ClearAOCSettings(); err != nil {
+		return fmt.Errorf("failed to clear AOC settings: %w", err)
+	}
+
+	fmt.Println("\nSuccessfully disconnected from AOC.")
+	return nil
+}
+
+// cleanupWorkspaceAOCConfig removes OAuth config files and clears MQTT metadata from all workspaces
+func cleanupWorkspaceAOCConfig() error {
+	homeDir := os.Getenv("HOME")
+	workspacesDir := filepath.Join(homeDir, ".config", "bitswan", "workspaces")
+
+	entries, err := os.ReadDir(workspacesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read workspaces directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		workspaceName := entry.Name()
+		workspacePath := filepath.Join(workspacesDir, workspaceName)
+
+		// Remove oauth-config.yaml
+		oauthConfigPath := filepath.Join(workspacePath, "oauth-config.yaml")
+		if _, err := os.Stat(oauthConfigPath); err == nil {
+			if err := os.Remove(oauthConfigPath); err != nil {
+				fmt.Printf("  Warning: Failed to remove %s: %v\n", oauthConfigPath, err)
+			} else {
+				fmt.Printf("  Removed OAuth config for workspace '%s'\n", workspaceName)
+			}
+		}
+
+		// Clear MQTT and workspace_id fields from metadata.yaml
+		metadataPath := filepath.Join(workspacePath, "metadata.yaml")
+		if err := clearWorkspaceAOCMetadata(metadataPath, workspaceName); err != nil {
+			fmt.Printf("  Warning: Failed to update metadata for workspace '%s': %v\n", workspaceName, err)
+		}
+	}
+
+	return nil
+}
+
+// clearWorkspaceAOCMetadata clears AOC-related fields from a workspace's metadata.yaml
+func clearWorkspaceAOCMetadata(metadataPath, workspaceName string) error {
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var metadata config.WorkspaceMetadata
+	if err := yaml.Unmarshal(data, &metadata); err != nil {
+		return fmt.Errorf("failed to parse metadata: %w", err)
+	}
+
+	metadata.WorkspaceId = nil
+	metadata.MqttUsername = nil
+	metadata.MqttPassword = nil
+	metadata.MqttBroker = nil
+	metadata.MqttPort = nil
+	metadata.MqttTopic = nil
+
+	if err := metadata.SaveToFile(metadataPath); err != nil {
+		return fmt.Errorf("failed to save metadata: %w", err)
+	}
+
+	fmt.Printf("  Cleared AOC metadata for workspace '%s'\n", workspaceName)
+	return nil
+}

--- a/internal/daemon/workspace_disconnect_from_aoc.go
+++ b/internal/daemon/workspace_disconnect_from_aoc.go
@@ -17,9 +17,10 @@ func (s *Server) runDisconnectFromAOC() error {
 	publisher.Disconnect()
 	fmt.Println("MQTT connection disconnected.")
 
-	// 2. Clean up workspace metadata and OAuth configs
+	// 2. Clean up workspace metadata and OAuth configs, collect workspace names
 	fmt.Println("Cleaning up workspace configurations...")
-	if err := cleanupWorkspaceAOCConfig(); err != nil {
+	workspaceNames, err := cleanupWorkspaceAOCConfig()
+	if err != nil {
 		fmt.Printf("Warning: Failed to clean up some workspace configs: %v\n", err)
 	}
 
@@ -30,23 +31,39 @@ func (s *Server) runDisconnectFromAOC() error {
 		return fmt.Errorf("failed to clear AOC settings: %w", err)
 	}
 
+	// 4. Regenerate docker-compose files and restart services for each workspace
+	// This removes OAuth/MQTT env vars from docker-compose and restarts editor/gitops
+	if len(workspaceNames) > 0 {
+		fmt.Println("\nUpdating workspace deployments...")
+		for _, name := range workspaceNames {
+			fmt.Printf("\n🔄 Updating workspace '%s'...\n", name)
+			if err := s.runWorkspaceUpdate([]string{name}); err != nil {
+				fmt.Printf("  Warning: Failed to update workspace '%s': %v\n", name, err)
+				continue
+			}
+			fmt.Printf("  ✅ Workspace '%s' updated and services restarted.\n", name)
+		}
+	}
+
 	fmt.Println("\nSuccessfully disconnected from AOC.")
 	return nil
 }
 
-// cleanupWorkspaceAOCConfig removes OAuth config files and clears MQTT metadata from all workspaces
-func cleanupWorkspaceAOCConfig() error {
+// cleanupWorkspaceAOCConfig removes OAuth config files and clears MQTT metadata from all workspaces.
+// Returns the list of workspace names that were cleaned up.
+func cleanupWorkspaceAOCConfig() ([]string, error) {
 	homeDir := os.Getenv("HOME")
 	workspacesDir := filepath.Join(homeDir, ".config", "bitswan", "workspaces")
 
 	entries, err := os.ReadDir(workspacesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return nil, nil
 		}
-		return fmt.Errorf("failed to read workspaces directory: %w", err)
+		return nil, fmt.Errorf("failed to read workspaces directory: %w", err)
 	}
 
+	var workspaceNames []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -54,6 +71,7 @@ func cleanupWorkspaceAOCConfig() error {
 
 		workspaceName := entry.Name()
 		workspacePath := filepath.Join(workspacesDir, workspaceName)
+		workspaceNames = append(workspaceNames, workspaceName)
 
 		// Remove oauth-config.yaml
 		oauthConfigPath := filepath.Join(workspacePath, "oauth-config.yaml")
@@ -72,7 +90,7 @@ func cleanupWorkspaceAOCConfig() error {
 		}
 	}
 
-	return nil
+	return workspaceNames, nil
 }
 
 // clearWorkspaceAOCMetadata clears AOC-related fields from a workspace's metadata.yaml

--- a/internal/daemon/workspace_disconnect_from_aoc.go
+++ b/internal/daemon/workspace_disconnect_from_aoc.go
@@ -6,16 +6,19 @@ import (
 	"path/filepath"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/config"
+	"github.com/bitswan-space/bitswan-workspaces/internal/services"
+	"github.com/bitswan-space/bitswan-workspaces/internal/workspace"
 	"gopkg.in/yaml.v3"
 )
 
 // runDisconnectFromAOC disconnects from AOC by cleaning up all AOC-related config
 func (s *Server) runDisconnectFromAOC() error {
-	// 1. Disconnect MQTT
+	// 1. Stop MQTT monitor and disconnect
+	stopMQTTMonitor()
 	publisher := GetMQTTPublisher()
 	publisher.Disconnect()
 
-	// 2. Clean up workspace metadata and OAuth configs, collect workspace names
+	// 2. Clean up workspace metadata and OAuth configs, collect deployable workspace names
 	workspaceNames, err := cleanupWorkspaceAOCConfig()
 	if err != nil {
 		fmt.Printf("Warning: Failed to clean up some workspace configs: %v\n", err)
@@ -32,7 +35,7 @@ func (s *Server) runDisconnectFromAOC() error {
 		fmt.Printf("Restarting %d workspace(s)...\n", len(workspaceNames))
 		for _, name := range workspaceNames {
 			fmt.Printf("  Restarting '%s'...\n", name)
-			if err := s.runWorkspaceUpdate([]string{name}); err != nil {
+			if err := restartWorkspace(name); err != nil {
 				fmt.Printf("  Warning: Failed to restart workspace '%s': %v\n", name, err)
 			}
 		}
@@ -40,7 +43,6 @@ func (s *Server) runDisconnectFromAOC() error {
 
 	// 5. Fix file ownership — the daemon runs as root so files we wrote
 	//    (metadata.yaml, docker-compose files) end up root-owned.
-	//    Restore ownership to user 1000 for the entire workspaces directory.
 	homeDir := os.Getenv("HOME")
 	workspacesDir := filepath.Join(homeDir, ".config", "bitswan", "workspaces")
 	if err := chownRecursive(workspacesDir); err != nil {
@@ -51,8 +53,43 @@ func (s *Server) runDisconnectFromAOC() error {
 	return nil
 }
 
+// restartWorkspace regenerates docker-compose files and restarts gitops + editor
+// for a single workspace. Unlike runWorkspaceUpdate this skips example updates
+// and does not wait for the editor health check.
+func restartWorkspace(workspaceName string) error {
+	// Regenerate and restart gitops
+	if err := workspace.UpdateWorkspaceDeployment(workspaceName, "", false, false); err != nil {
+		return fmt.Errorf("gitops: %w", err)
+	}
+
+	// Regenerate and restart editor if enabled
+	editorService, err := services.NewEditorService(workspaceName)
+	if err != nil {
+		return nil // workspace doesn't exist or isn't set up, skip
+	}
+	if !editorService.IsEnabled() {
+		return nil
+	}
+
+	if err := editorService.StopContainer(); err != nil {
+		return fmt.Errorf("editor stop: %w", err)
+	}
+	if err := fixEditorPermissions(workspaceName); err != nil {
+		return fmt.Errorf("editor permissions: %w", err)
+	}
+	if err := editorService.RegenerateDockerCompose("", false, false); err != nil {
+		return fmt.Errorf("editor regenerate: %w", err)
+	}
+	if err := editorService.StartContainer(); err != nil {
+		return fmt.Errorf("editor start: %w", err)
+	}
+
+	return nil
+}
+
 // cleanupWorkspaceAOCConfig removes OAuth config files and clears MQTT metadata from all workspaces.
-// Returns the list of workspace names that were cleaned up.
+// Returns the list of workspace names that have a full deployment (metadata.yaml + deployment dir)
+// and should be restarted.
 func cleanupWorkspaceAOCConfig() ([]string, error) {
 	homeDir := os.Getenv("HOME")
 	workspacesDir := filepath.Join(homeDir, ".config", "bitswan", "workspaces")
@@ -65,7 +102,7 @@ func cleanupWorkspaceAOCConfig() ([]string, error) {
 		return nil, fmt.Errorf("failed to read workspaces directory: %w", err)
 	}
 
-	var workspaceNames []string
+	var deployableWorkspaces []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -73,9 +110,10 @@ func cleanupWorkspaceAOCConfig() ([]string, error) {
 
 		workspaceName := entry.Name()
 		workspacePath := filepath.Join(workspacesDir, workspaceName)
-		workspaceNames = append(workspaceNames, workspaceName)
+		metadataPath := filepath.Join(workspacePath, "metadata.yaml")
+		deploymentDir := filepath.Join(workspacePath, "deployment")
 
-		// Remove oauth-config.yaml
+		// Remove oauth-config.yaml if present
 		oauthConfigPath := filepath.Join(workspacePath, "oauth-config.yaml")
 		if _, err := os.Stat(oauthConfigPath); err == nil {
 			if err := os.Remove(oauthConfigPath); err != nil {
@@ -84,13 +122,17 @@ func cleanupWorkspaceAOCConfig() ([]string, error) {
 		}
 
 		// Clear MQTT and workspace_id fields from metadata.yaml
-		metadataPath := filepath.Join(workspacePath, "metadata.yaml")
 		if err := clearWorkspaceAOCMetadata(metadataPath); err != nil {
-			fmt.Printf("  Warning: Failed to clear metadata for workspace '%s': %v\n", workspaceName, err)
+			continue
+		}
+
+		// Only restart workspaces that have a full deployment
+		if _, err := os.Stat(deploymentDir); err == nil {
+			deployableWorkspaces = append(deployableWorkspaces, workspaceName)
 		}
 	}
 
-	return workspaceNames, nil
+	return deployableWorkspaces, nil
 }
 
 // clearWorkspaceAOCMetadata clears AOC-related fields from a workspace's metadata.yaml

--- a/internal/daemon/workspace_disconnect_from_aoc.go
+++ b/internal/daemon/workspace_disconnect_from_aoc.go
@@ -12,40 +12,34 @@ import (
 // runDisconnectFromAOC disconnects from AOC by cleaning up all AOC-related config
 func (s *Server) runDisconnectFromAOC() error {
 	// 1. Disconnect MQTT
-	fmt.Println("Disconnecting MQTT connection...")
 	publisher := GetMQTTPublisher()
 	publisher.Disconnect()
-	fmt.Println("MQTT connection disconnected.")
 
 	// 2. Clean up workspace metadata and OAuth configs, collect workspace names
-	fmt.Println("Cleaning up workspace configurations...")
 	workspaceNames, err := cleanupWorkspaceAOCConfig()
 	if err != nil {
 		fmt.Printf("Warning: Failed to clean up some workspace configs: %v\n", err)
 	}
 
 	// 3. Clear AOC settings from the main config
-	fmt.Println("Removing AOC credentials...")
 	cfg := config.NewAutomationServerConfig()
 	if err := cfg.ClearAOCSettings(); err != nil {
 		return fmt.Errorf("failed to clear AOC settings: %w", err)
 	}
 
 	// 4. Regenerate docker-compose files and restart services for each workspace
-	// This removes OAuth/MQTT env vars from docker-compose and restarts editor/gitops
 	if len(workspaceNames) > 0 {
-		fmt.Println("\nUpdating workspace deployments...")
+		fmt.Printf("Restarting %d workspace(s)...\n", len(workspaceNames))
 		for _, name := range workspaceNames {
-			fmt.Printf("\n🔄 Updating workspace '%s'...\n", name)
+			fmt.Printf("  Restarting '%s'...\n", name)
 			if err := s.runWorkspaceUpdate([]string{name}); err != nil {
-				fmt.Printf("  Warning: Failed to update workspace '%s': %v\n", name, err)
+				fmt.Printf("  Warning: Failed to restart workspace '%s': %v\n", name, err)
 				continue
 			}
-			fmt.Printf("  ✅ Workspace '%s' updated and services restarted.\n", name)
 		}
 	}
 
-	fmt.Println("\nSuccessfully disconnected from AOC.")
+	fmt.Println("\nDisconnected from AOC.")
 	return nil
 }
 
@@ -77,16 +71,14 @@ func cleanupWorkspaceAOCConfig() ([]string, error) {
 		oauthConfigPath := filepath.Join(workspacePath, "oauth-config.yaml")
 		if _, err := os.Stat(oauthConfigPath); err == nil {
 			if err := os.Remove(oauthConfigPath); err != nil {
-				fmt.Printf("  Warning: Failed to remove %s: %v\n", oauthConfigPath, err)
-			} else {
-				fmt.Printf("  Removed OAuth config for workspace '%s'\n", workspaceName)
+				fmt.Printf("  Warning: Failed to remove OAuth config for workspace '%s': %v\n", workspaceName, err)
 			}
 		}
 
 		// Clear MQTT and workspace_id fields from metadata.yaml
 		metadataPath := filepath.Join(workspacePath, "metadata.yaml")
-		if err := clearWorkspaceAOCMetadata(metadataPath, workspaceName); err != nil {
-			fmt.Printf("  Warning: Failed to update metadata for workspace '%s': %v\n", workspaceName, err)
+		if err := clearWorkspaceAOCMetadata(metadataPath); err != nil {
+			fmt.Printf("  Warning: Failed to clear metadata for workspace '%s': %v\n", workspaceName, err)
 		}
 	}
 
@@ -94,7 +86,7 @@ func cleanupWorkspaceAOCConfig() ([]string, error) {
 }
 
 // clearWorkspaceAOCMetadata clears AOC-related fields from a workspace's metadata.yaml
-func clearWorkspaceAOCMetadata(metadataPath, workspaceName string) error {
+func clearWorkspaceAOCMetadata(metadataPath string) error {
 	data, err := os.ReadFile(metadataPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -115,10 +107,5 @@ func clearWorkspaceAOCMetadata(metadataPath, workspaceName string) error {
 	metadata.MqttPort = nil
 	metadata.MqttTopic = nil
 
-	if err := metadata.SaveToFile(metadataPath); err != nil {
-		return fmt.Errorf("failed to save metadata: %w", err)
-	}
-
-	fmt.Printf("  Cleared AOC metadata for workspace '%s'\n", workspaceName)
-	return nil
+	return metadata.SaveToFile(metadataPath)
 }

--- a/internal/daemon/workspace_disconnect_from_aoc.go
+++ b/internal/daemon/workspace_disconnect_from_aoc.go
@@ -34,9 +34,17 @@ func (s *Server) runDisconnectFromAOC() error {
 			fmt.Printf("  Restarting '%s'...\n", name)
 			if err := s.runWorkspaceUpdate([]string{name}); err != nil {
 				fmt.Printf("  Warning: Failed to restart workspace '%s': %v\n", name, err)
-				continue
 			}
 		}
+	}
+
+	// 5. Fix file ownership — the daemon runs as root so files we wrote
+	//    (metadata.yaml, docker-compose files) end up root-owned.
+	//    Restore ownership to user 1000 for the entire workspaces directory.
+	homeDir := os.Getenv("HOME")
+	workspacesDir := filepath.Join(homeDir, ".config", "bitswan", "workspaces")
+	if err := chownRecursive(workspacesDir); err != nil {
+		fmt.Printf("Warning: Failed to fix file ownership: %v\n", err)
 	}
 
 	fmt.Println("\nDisconnected from AOC.")

--- a/internal/daemon/workspace_update.go
+++ b/internal/daemon/workspace_update.go
@@ -229,10 +229,8 @@ func fixEditorPermissions(workspaceName string) error {
 		}
 
 		// Chown the directory and all its contents to 1000:1000
-		chownCom := exec.Command("chown", "-R", "1000:1000", dir.path)
-		output, err := chownCom.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("failed to chown %s dir (%s): %w, output: %s", dir.name, dir.path, err, string(output))
+		if err := chownRecursive(dir.path); err != nil {
+			return fmt.Errorf("failed to chown %s dir (%s): %w", dir.name, dir.path, err)
 		}
 
 		// Set permissions: 755 for directories, 644 for files


### PR DESCRIPTION
## Summary
- **Prevent double registration**: `bitswan register` now detects if the server is already registered to an AOC instance and returns an error with instructions to disconnect first
- **New `bitswan disconnect-from-aoc` command**: Safely disconnects from the current AOC instance by removing AOC credentials, OAuth config files, and MQTT settings from workspace metadata — without deleting workspaces or their data
- **Confirmation required**: Disconnect requires typing "yes" to confirm

## What disconnect cleans up
- AOC credentials from `automation_server_config.toml` (access token, server ID, AOC URL)
- `oauth-config.yaml` files from all workspace directories
- MQTT connection settings (`workspace_id`, `mqtt_*` fields) from workspace `metadata.yaml`
- Active MQTT connection via the daemon

## What disconnect preserves
- All workspaces and their data (gitops repos, deployments, secrets, etc.)
- Local server token and active workspace setting
- All workspace configurations unrelated to AOC (domain, editor URL, gitops URL, etc.)

## Test plan
- [ ] Run `bitswan register` on an already-registered server — should show error with disconnect instructions
- [ ] Run `bitswan disconnect-from-aoc` — should list what will be cleaned up, require "yes" confirmation
- [ ] After disconnect, verify `automation_server_config.toml` has empty AOC section
- [ ] After disconnect, verify `oauth-config.yaml` files are removed from workspaces
- [ ] After disconnect, verify workspace `metadata.yaml` files have MQTT fields cleared
- [ ] After disconnect, run `bitswan register` with new credentials — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)