### PR TITLE
Add WireGuard VPN server management

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bitswan-space/bitswan-workspaces/cmd/certauthority"
 	"github.com/bitswan-space/bitswan-workspaces/cmd/ingress"
 	"github.com/bitswan-space/bitswan-workspaces/cmd/test"
+	"github.com/bitswan-space/bitswan-workspaces/cmd/vpn"
 	"github.com/spf13/cobra"
 )
 
@@ -63,6 +64,7 @@ func newRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(automationserverdaemon.NewAutomationServerDaemonCmd())     // automation server daemon subcommand
 	cmd.AddCommand(automation.NewAutomationCmd())                             // automation subcommand
 	cmd.AddCommand(test.NewTestCmd())                                         // _test subcommand (hidden)
+	cmd.AddCommand(vpn.NewVPNCmd())                                          // vpn subcommand
 	cmd.AddCommand(newCompletionCmd())                                        // completion subcommand
 
 	// Set the version for the daemon server

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -1,0 +1,211 @@
+package vpn
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+func NewVPNCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vpn",
+		Short: "Manage WireGuard VPN for the platform",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newStatusCmd())
+	cmd.AddCommand(newListUsersCmd())
+	cmd.AddCommand(newGenerateCredsCmd())
+	cmd.AddCommand(newRevokeCmd())
+
+	return cmd
+}
+
+func getDaemonClient() *daemon.Client {
+	client, err := daemon.NewClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Run 'bitswan automation-server-daemon init' to start it.")
+		os.Exit(1)
+	}
+	return client
+}
+
+func newInitCmd() *cobra.Command {
+	var endpoint string
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize WireGuard VPN for the platform",
+		Long:  "Sets up the WireGuard server, VPN network, and VPN Traefik. All workspaces will use this VPN.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if endpoint == "" {
+				return fmt.Errorf("--endpoint is required (e.g., vpn.example.com or 203.0.113.1)")
+			}
+
+			client := getDaemonClient()
+			body := fmt.Sprintf(`{"endpoint": %q}`, endpoint)
+			req, err := http.NewRequest("POST", "http://daemon/vpn/init", strings.NewReader(body))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return fmt.Errorf("failed to initialize VPN: %w", err)
+			}
+			defer resp.Body.Close()
+
+			var result map[string]string
+			json.NewDecoder(resp.Body).Decode(&result)
+			fmt.Println(result["message"])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Public hostname or IP for VPN connections (required)")
+
+	return cmd
+}
+
+func newStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show VPN status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := getDaemonClient()
+			req, _ := http.NewRequest("GET", "http://daemon/vpn/status", nil)
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			var status map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&status)
+
+			initialized, _ := status["initialized"].(bool)
+			if !initialized {
+				fmt.Println("VPN: not initialized")
+				fmt.Println("Run 'bitswan vpn init --endpoint <hostname>' to set up")
+				return nil
+			}
+
+			enabled, _ := status["enabled"].(bool)
+			if enabled {
+				fmt.Println("VPN: enabled")
+			} else {
+				fmt.Println("VPN: disabled")
+			}
+			if pub, ok := status["server_public_key"].(string); ok {
+				fmt.Printf("Server public key: %s\n", pub)
+			}
+			if count, ok := status["user_count"].(float64); ok {
+				fmt.Printf("Users: %d\n", int(count))
+			}
+			return nil
+		},
+	}
+}
+
+func newListUsersCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-users",
+		Short: "List VPN users",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := getDaemonClient()
+			req, _ := http.NewRequest("GET", "http://daemon/vpn/users", nil)
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			var users []map[string]string
+			json.NewDecoder(resp.Body).Decode(&users)
+
+			if len(users) == 0 {
+				fmt.Println("No VPN users.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "USER ID\tIP\tPUBLIC KEY")
+			for _, u := range users {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", u["id"], u["ip"], u["public_key"])
+			}
+			w.Flush()
+			return nil
+		},
+	}
+}
+
+func newGenerateCredsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "generate-credentials <user-id>",
+		Short: "Generate VPN credentials for a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			userID := args[0]
+			client := getDaemonClient()
+			body := fmt.Sprintf(`{"user_id": %q}`, userID)
+			req, err := http.NewRequest("POST", "http://daemon/vpn/credentials", strings.NewReader(body))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			outPath := userID + ".conf"
+			f, err := os.Create(outPath)
+			if err != nil {
+				return fmt.Errorf("failed to create %s: %w", outPath, err)
+			}
+			defer f.Close()
+			io.Copy(f, resp.Body)
+
+			fmt.Printf("VPN config written to %s\n", outPath)
+			return nil
+		},
+	}
+}
+
+func newRevokeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke <user-id>",
+		Short: "Revoke VPN access for a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			userID := args[0]
+			client := getDaemonClient()
+			body := fmt.Sprintf(`{"user_id": %q}`, userID)
+			req, err := http.NewRequest("POST", "http://daemon/vpn/revoke", strings.NewReader(body))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			fmt.Printf("Revoked VPN access for %s\n", userID)
+			return nil
+		},
+	}
+}

--- a/internal/daemon/ingress.go
+++ b/internal/daemon/ingress.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -44,6 +45,11 @@ type IngressAddRouteRequest struct {
 	CertsDir      string `json:"certs_dir,omitempty"`
 	Secret        string `json:"secret,omitempty"`
 	WorkspaceName string `json:"workspace_name,omitempty"`
+	// IngressTarget controls which ingress receives the route when VPN is enabled.
+	// "external" = internet-facing Traefik only
+	// "internal" = VPN Traefik only
+	// "both" or "" = both (default, backward compatible)
+	IngressTarget string `json:"ingress_target,omitempty"`
 }
 
 // IngressAddRouteResponse represents the response from adding a route
@@ -635,9 +641,21 @@ func resolveWorkspaceName(req IngressAddRouteRequest, jwtToken string) string {
 	return ""
 }
 
+// IsVPNEnabled checks whether VPN mode is active.
+func IsVPNEnabled() bool {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(homeDir, ".config", "bitswan", "vpn", "enabled"))
+	return err == nil
+}
+
 // addRouteToIngress adds a route using whichever ingress is running.
 // For Traefik with a workspace name, it sets up two-tier routing
 // (platform traefik → workspace sub-traefik → container).
+// When VPN is enabled, routes are dispatched to external Traefik,
+// VPN Traefik, or both based on req.IngressTarget.
 func addRouteToIngress(req IngressAddRouteRequest, jwtToken string) error {
 	if req.Hostname == "" {
 		return fmt.Errorf("hostname is required")
@@ -648,15 +666,59 @@ func addRouteToIngress(req IngressAddRouteRequest, jwtToken string) error {
 
 	ingressType := DetectIngressType()
 
-	switch ingressType {
-	case IngressCaddy:
-		return addRouteCaddy(req)
-	case IngressTraefik:
-		workspaceName := resolveWorkspaceName(req, jwtToken)
-		return addRouteTraefik(req, workspaceName)
+	if !IsVPNEnabled() {
+		// No VPN — single ingress, ignore IngressTarget
+		switch ingressType {
+		case IngressCaddy:
+			return addRouteCaddy(req)
+		case IngressTraefik:
+			workspaceName := resolveWorkspaceName(req, jwtToken)
+			return addRouteTraefik(req, workspaceName)
+		}
+		return fmt.Errorf("no ingress proxy detected")
 	}
 
-	return fmt.Errorf("no ingress proxy detected")
+	// VPN enabled — dispatch to external, internal, or both
+	target := req.IngressTarget
+	if target == "" {
+		target = "both"
+	}
+
+	var errs []error
+
+	if target == "external" || target == "both" {
+		switch ingressType {
+		case IngressCaddy:
+			if err := addRouteCaddy(req); err != nil {
+				errs = append(errs, fmt.Errorf("external ingress: %w", err))
+			}
+		case IngressTraefik:
+			workspaceName := resolveWorkspaceName(req, jwtToken)
+			if err := addRouteTraefik(req, workspaceName); err != nil {
+				errs = append(errs, fmt.Errorf("external ingress: %w", err))
+			}
+		}
+	}
+
+	if target == "internal" || target == "both" {
+		if err := addRouteVPNTraefik(req); err != nil {
+			errs = append(errs, fmt.Errorf("vpn ingress: %w", err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%v", errs)
+	}
+	return nil
+}
+
+// addRouteVPNTraefik adds a route to the VPN-internal Traefik instance.
+func addRouteVPNTraefik(req IngressAddRouteRequest) error {
+	vpnTraefikURL := os.Getenv("BITSWAN_VPN_TRAEFIK_HOST")
+	if vpnTraefikURL == "" {
+		vpnTraefikURL = "http://traefik-vpn:8080"
+	}
+	return traefikapi.AddRouteWithTraefik(req.Hostname, req.Upstream, vpnTraefikURL)
 }
 
 // addRouteCaddy adds a route to Caddy

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -151,6 +151,13 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	mux.HandleFunc("/service", s.authMiddleware(s.handleService))
 	mux.HandleFunc("/service/", s.authMiddleware(s.handleService))
 
+	// VPN endpoints (authenticated)
+	mux.HandleFunc("/vpn/init", s.authMiddleware(s.handleVPNInit))
+	mux.HandleFunc("/vpn/status", s.authMiddleware(s.handleVPNStatus))
+	mux.HandleFunc("/vpn/credentials", s.authMiddleware(s.handleVPNGenerateCredentials))
+	mux.HandleFunc("/vpn/revoke", s.authMiddleware(s.handleVPNRevoke))
+	mux.HandleFunc("/vpn/users", s.authMiddleware(s.handleVPNListUsers))
+
 	// MQTT endpoints (authenticated)
 	mux.HandleFunc("/mqtt/reinitialize", s.authMiddleware(s.handleMQTTReinitialize))
 

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -1,0 +1,135 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/vpn"
+)
+
+func vpnManager() *vpn.Manager {
+	homeDir, _ := os.UserHomeDir()
+	return vpn.NewManager(filepath.Join(homeDir, ".config", "bitswan"))
+}
+
+func (s *Server) handleVPNInit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		Endpoint string `json:"endpoint"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.Endpoint == "" {
+		http.Error(w, "endpoint is required (e.g., vpn.example.com)", http.StatusBadRequest)
+		return
+	}
+
+	mgr := vpnManager()
+	if err := mgr.Init(body.Endpoint); err != nil {
+		http.Error(w, fmt.Sprintf("failed to initialize VPN: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "initialized",
+		"message": "WireGuard VPN initialized. Start the container with 'bitswan vpn start'.",
+	})
+}
+
+func (s *Server) handleVPNStatus(w http.ResponseWriter, r *http.Request) {
+	mgr := vpnManager()
+	initialized := mgr.IsInitialized()
+
+	result := map[string]interface{}{
+		"enabled":     IsVPNEnabled(),
+		"initialized": initialized,
+	}
+
+	if initialized {
+		pub, _ := mgr.ServerPublicKey()
+		users, _ := mgr.ListClients()
+		result["server_public_key"] = pub
+		result["user_count"] = len(users)
+	}
+
+	json.NewEncoder(w).Encode(result)
+}
+
+func (s *Server) handleVPNGenerateCredentials(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.UserID == "" {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+
+	mgr := vpnManager()
+	conf, err := mgr.GenerateClient(body.UserID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to generate credentials: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.conf", body.UserID))
+	w.Write(conf)
+}
+
+func (s *Server) handleVPNRevoke(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.UserID == "" {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+
+	mgr := vpnManager()
+	if err := mgr.RevokeClient(body.UserID); err != nil {
+		http.Error(w, fmt.Sprintf("failed to revoke: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{"status": "revoked", "user_id": body.UserID})
+}
+
+func (s *Server) handleVPNListUsers(w http.ResponseWriter, r *http.Request) {
+	mgr := vpnManager()
+	users, err := mgr.ListClients()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to list users: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if users == nil {
+		users = []vpn.VPNUser{}
+	}
+	json.NewEncoder(w).Encode(users)
+}

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -315,6 +315,58 @@ func CreateVPNTraefikDockerComposeFile(traefikPath string) (string, error) {
 	return buf.String(), nil
 }
 
+// CreateWireGuardDockerComposeFile creates a docker-compose file for the WireGuard VPN server.
+// vpnPath: path to VPN config directory (e.g., ~/.config/bitswan/vpn)
+// listenPort: UDP port for WireGuard (default 51820)
+func CreateWireGuardDockerComposeFile(vpnPath string, listenPort int) (string, error) {
+	if listenPort == 0 {
+		listenPort = 51820
+	}
+
+	dockerCompose := map[string]interface{}{
+		"version": "3.8",
+		"services": map[string]interface{}{
+			"wireguard": map[string]interface{}{
+				"image":          "linuxserver/wireguard:latest",
+				"restart":        "always",
+				"container_name": "wireguard",
+				"cap_add":        []string{"NET_ADMIN", "SYS_MODULE"},
+				"ports":          []string{fmt.Sprintf("%d:%d/udp", listenPort, listenPort)},
+				"networks":       []string{"bitswan_network", "bitswan_vpn_network"},
+				"environment": []string{
+					"PUID=1000",
+					"PGID=1000",
+				},
+				"volumes": []string{
+					vpnPath + ":/config:z",
+					"/lib/modules:/lib/modules:ro",
+				},
+				"sysctls": []string{
+					"net.ipv4.conf.all.src_valid_mark=1",
+					"net.ipv4.ip_forward=1",
+				},
+			},
+		},
+		"networks": map[string]interface{}{
+			"bitswan_network": map[string]interface{}{
+				"external": true,
+			},
+			"bitswan_vpn_network": map[string]interface{}{
+				"external": true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(dockerCompose); err != nil {
+		return "", fmt.Errorf("failed to encode docker-compose data structure: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
 // CreateWorkspaceTraefikDockerComposeFile creates a docker-compose file for workspace sub-traefik.
 // workspaceName: name of the workspace (used for container name)
 // traefikPath: path to traefik config directory

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -275,6 +275,46 @@ func CreateTraefikDockerComposeFile(traefikPath string, networks ...string) (str
 	return buf.String(), nil
 }
 
+// CreateVPNTraefikDockerComposeFile creates a docker-compose file for the VPN-internal Traefik.
+// It has no host ports — only reachable from VPN clients via the WireGuard server.
+// traefikPath: path to the VPN traefik config directory (e.g., ~/.config/bitswan/traefik-vpn)
+func CreateVPNTraefikDockerComposeFile(traefikPath string) (string, error) {
+	traefikVolumes := []string{
+		traefikPath + "/traefik.yml:/etc/traefik/traefik.yml:z",
+	}
+
+	dockerCompose := map[string]interface{}{
+		"version": "3.8",
+		"services": map[string]interface{}{
+			"traefik-vpn": map[string]interface{}{
+				"image":          "traefik:v3.6",
+				"restart":        "always",
+				"container_name": "traefik-vpn",
+				// No host ports — only reachable from VPN subnet
+				"networks": []string{"bitswan_network", "bitswan_vpn_network"},
+				"volumes":  traefikVolumes,
+			},
+		},
+		"networks": map[string]interface{}{
+			"bitswan_network": map[string]interface{}{
+				"external": true,
+			},
+			"bitswan_vpn_network": map[string]interface{}{
+				"external": true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(dockerCompose); err != nil {
+		return "", fmt.Errorf("failed to encode docker-compose data structure: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
 // CreateWorkspaceTraefikDockerComposeFile creates a docker-compose file for workspace sub-traefik.
 // workspaceName: name of the workspace (used for container name)
 // traefikPath: path to traefik config directory

--- a/internal/vpn/wireguard.go
+++ b/internal/vpn/wireguard.go
@@ -1,0 +1,352 @@
+package vpn
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	VPNSubnet    = "10.8.0.0/24"
+	ServerIP     = "10.8.0.1"
+	ListenPort   = 51820
+	DNSServer    = "10.8.0.1"
+	vpnDirName   = "vpn"
+	usersDirName = "users"
+)
+
+// VPNUser represents a registered VPN user.
+type VPNUser struct {
+	ID        string `json:"id" yaml:"id"`
+	PublicKey string `json:"public_key" yaml:"public_key"`
+	IP        string `json:"ip" yaml:"ip"`
+}
+
+// Manager handles WireGuard server and client configuration.
+type Manager struct {
+	baseDir string // ~/.config/bitswan/vpn
+	mu      sync.Mutex
+}
+
+// NewManager creates a VPN manager rooted at the given base dir.
+func NewManager(bitswanConfigDir string) *Manager {
+	return &Manager{
+		baseDir: filepath.Join(bitswanConfigDir, vpnDirName),
+	}
+}
+
+// IsInitialized returns true if the VPN server has been set up.
+func (m *Manager) IsInitialized() bool {
+	_, err := os.Stat(filepath.Join(m.baseDir, "server_private.key"))
+	return err == nil
+}
+
+// Init generates the server keypair and writes wg0.conf.
+func (m *Manager) Init(serverEndpoint string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.IsInitialized() {
+		return fmt.Errorf("VPN already initialized")
+	}
+
+	os.MkdirAll(m.baseDir, 0700)
+	os.MkdirAll(filepath.Join(m.baseDir, usersDirName), 0700)
+
+	// Generate server keypair
+	serverPriv, serverPub, err := generateKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate server keypair: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(m.baseDir, "server_private.key"), []byte(serverPriv), 0600); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(m.baseDir, "server_public.key"), []byte(serverPub), 0644); err != nil {
+		return err
+	}
+
+	// Write initial server config (no peers yet)
+	conf := fmt.Sprintf(`[Interface]
+Address = %s/24
+ListenPort = %d
+PrivateKey = %s
+PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+`, ServerIP, ListenPort, serverPriv)
+
+	if err := os.WriteFile(filepath.Join(m.baseDir, "wg0.conf"), []byte(conf), 0600); err != nil {
+		return err
+	}
+
+	// Store server endpoint for client configs
+	meta := map[string]string{
+		"endpoint":   serverEndpoint,
+		"server_pub": serverPub,
+	}
+	metaBytes, _ := yaml.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(m.baseDir, "meta.yaml"), metaBytes, 0644); err != nil {
+		return err
+	}
+
+	// Write the enabled flag
+	return os.WriteFile(filepath.Join(m.baseDir, "enabled"), []byte("true\n"), 0644)
+}
+
+// GenerateClient creates a new VPN client and returns the client .conf content.
+func (m *Manager) GenerateClient(userID string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.IsInitialized() {
+		return nil, fmt.Errorf("VPN not initialized")
+	}
+
+	userDir := filepath.Join(m.baseDir, usersDirName, userID)
+	if _, err := os.Stat(userDir); err == nil {
+		return nil, fmt.Errorf("user %s already exists", userID)
+	}
+
+	// Read server metadata
+	metaBytes, err := os.ReadFile(filepath.Join(m.baseDir, "meta.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read server metadata: %w", err)
+	}
+	var meta map[string]string
+	yaml.Unmarshal(metaBytes, &meta)
+	serverEndpoint := meta["endpoint"]
+	serverPub := meta["server_pub"]
+
+	// Generate client keypair
+	clientPriv, clientPub, err := generateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate client keypair: %w", err)
+	}
+
+	// Assign next available IP
+	clientIP, err := m.nextAvailableIP()
+	if err != nil {
+		return nil, err
+	}
+
+	// Save client info
+	os.MkdirAll(userDir, 0700)
+	user := VPNUser{
+		ID:        userID,
+		PublicKey: clientPub,
+		IP:        clientIP,
+	}
+	userBytes, _ := yaml.Marshal(user)
+	os.WriteFile(filepath.Join(userDir, "user.yaml"), userBytes, 0644)
+	os.WriteFile(filepath.Join(userDir, "private.key"), []byte(clientPriv), 0600)
+
+	// Build client config
+	clientConf := fmt.Sprintf(`[Interface]
+PrivateKey = %s
+Address = %s/32
+DNS = %s
+
+[Peer]
+PublicKey = %s
+Endpoint = %s:%d
+AllowedIPs = %s
+PersistentKeepalive = 25
+`, clientPriv, clientIP, DNSServer, serverPub, serverEndpoint, ListenPort, VPNSubnet)
+
+	os.WriteFile(filepath.Join(userDir, "client.conf"), []byte(clientConf), 0600)
+
+	// Add peer to server config
+	if err := m.addPeerToServerConfig(clientPub, clientIP); err != nil {
+		return nil, fmt.Errorf("failed to add peer to server: %w", err)
+	}
+
+	return []byte(clientConf), nil
+}
+
+// RevokeClient removes a VPN client.
+func (m *Manager) RevokeClient(userID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	userDir := filepath.Join(m.baseDir, usersDirName, userID)
+	userFile := filepath.Join(userDir, "user.yaml")
+
+	data, err := os.ReadFile(userFile)
+	if err != nil {
+		return fmt.Errorf("user %s not found", userID)
+	}
+	var user VPNUser
+	yaml.Unmarshal(data, &user)
+
+	// Remove peer from server config
+	if err := m.removePeerFromServerConfig(user.PublicKey); err != nil {
+		return err
+	}
+
+	// Delete user directory
+	return os.RemoveAll(userDir)
+}
+
+// ListClients returns all registered VPN users.
+func (m *Manager) ListClients() ([]VPNUser, error) {
+	usersDir := filepath.Join(m.baseDir, usersDirName)
+	entries, err := os.ReadDir(usersDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var users []VPNUser
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(usersDir, entry.Name(), "user.yaml"))
+		if err != nil {
+			continue
+		}
+		var user VPNUser
+		yaml.Unmarshal(data, &user)
+		users = append(users, user)
+	}
+	return users, nil
+}
+
+// ServerPublicKey returns the server's public key.
+func (m *Manager) ServerPublicKey() (string, error) {
+	data, err := os.ReadFile(filepath.Join(m.baseDir, "server_public.key"))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// ReloadServer signals the WireGuard container to reload its config.
+func (m *Manager) ReloadServer() error {
+	// docker exec wireguard wg syncconf wg0 <(wg-quick strip wg0)
+	cmd := exec.Command("docker", "exec", "wireguard", "bash", "-c",
+		"wg syncconf wg0 <(wg-quick strip /config/wg0.conf)")
+	return cmd.Run()
+}
+
+// --- internal helpers ---
+
+func (m *Manager) nextAvailableIP() (string, error) {
+	users, _ := m.ListClients()
+	used := map[string]bool{ServerIP: true}
+	for _, u := range users {
+		used[u.IP] = true
+	}
+
+	// Assign from 10.8.0.2 to 10.8.0.254
+	for i := 2; i < 255; i++ {
+		ip := fmt.Sprintf("10.8.0.%d", i)
+		if !used[ip] {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("no available IP addresses in VPN subnet")
+}
+
+func (m *Manager) addPeerToServerConfig(publicKey, ip string) error {
+	confPath := filepath.Join(m.baseDir, "wg0.conf")
+	f, err := os.OpenFile(confPath, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	peer := fmt.Sprintf("\n[Peer]\nPublicKey = %s\nAllowedIPs = %s/32\n", publicKey, ip)
+	_, err = f.WriteString(peer)
+	if err != nil {
+		return err
+	}
+
+	return m.ReloadServer()
+}
+
+func (m *Manager) removePeerFromServerConfig(publicKey string) error {
+	confPath := filepath.Join(m.baseDir, "wg0.conf")
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var result []string
+	skip := false
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "[Peer]" {
+			skip = false
+		}
+		if skip {
+			continue
+		}
+		if strings.Contains(line, publicKey) {
+			// Remove the [Peer] header we just added
+			if len(result) > 0 && strings.TrimSpace(result[len(result)-1]) == "[Peer]" {
+				result = result[:len(result)-1]
+			}
+			skip = true
+			continue
+		}
+		result = append(result, line)
+	}
+
+	if err := os.WriteFile(confPath, []byte(strings.Join(result, "\n")), 0600); err != nil {
+		return err
+	}
+
+	return m.ReloadServer()
+}
+
+func generateKeyPair() (privateKey, publicKey string, err error) {
+	// Try using wg command if available
+	privCmd := exec.Command("wg", "genkey")
+	privOut, err := privCmd.Output()
+	if err == nil {
+		priv := strings.TrimSpace(string(privOut))
+		pubCmd := exec.Command("wg", "pubkey")
+		pubCmd.Stdin = strings.NewReader(priv)
+		pubOut, err := pubCmd.Output()
+		if err == nil {
+			return priv, strings.TrimSpace(string(pubOut)), nil
+		}
+	}
+
+	// Fallback: generate Curve25519 keypair manually
+	var private [32]byte
+	if _, err := rand.Read(private[:]); err != nil {
+		return "", "", err
+	}
+	// Clamp private key per Curve25519 spec
+	private[0] &= 248
+	private[31] &= 127
+	private[31] |= 64
+
+	priv := base64.StdEncoding.EncodeToString(private[:])
+
+	// Compute public key via Curve25519 scalar multiplication
+	// For simplicity, shell out to wg pubkey if available, otherwise error
+	pubCmd := exec.Command("wg", "pubkey")
+	pubCmd.Stdin = strings.NewReader(priv)
+	pubOut, err := pubCmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("wg command not available for key generation: %w", err)
+	}
+
+	return priv, strings.TrimSpace(string(pubOut)), nil
+}
+
+// Silence unused import warning
+var _ = net.ParseCIDR


### PR DESCRIPTION
## Summary
Second PR in the WireGuard VPN series. Platform-level VPN — one WireGuard server shared across all workspaces.

- `internal/vpn/wireguard.go`: Keypair generation, client config generation, peer management, server config reload
- `internal/daemon/vpn.go`: HTTP endpoints: `/vpn/init`, `/vpn/status`, `/vpn/credentials`, `/vpn/revoke`, `/vpn/users`
- `internal/dockercompose/`: WireGuard container + VPN Traefik compose generation
- `cmd/vpn/`: CLI commands: `bitswan vpn init --endpoint`, `status`, `list-users`, `generate-credentials`, `revoke`

## Series
1. Dual-ingress infrastructure (#328)
2. **This PR: WireGuard server management**
3. VPN admin UI and magic links
4. Route classification in gitops

## Test plan
- [ ] `bitswan vpn init --endpoint vpn.example.com` creates server config
- [ ] `bitswan vpn generate-credentials admin` creates client .conf
- [ ] `bitswan vpn list-users` shows the user
- [ ] `bitswan vpn revoke admin` removes the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)