### PR TITLE
Add VPN admin UI and magic link credential distribution

### DIFF
--- a/cmd/automationserverdaemon/init.go
+++ b/cmd/automationserverdaemon/init.go
@@ -86,6 +86,19 @@ func runInitCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Generate a random name for the automation server if none exists
+	serverConfig, _ := cfg.LoadConfig()
+	if serverConfig != nil && serverConfig.Name == "" {
+		randomName := config.GenerateRandomName()
+		if err := cfg.SetNameAndSlug(randomName); err != nil {
+			fmt.Printf("Warning: failed to save server name: %v\n", err)
+		} else {
+			fmt.Printf("Automation server name: %s (slug: %s)\n", randomName, config.Slugify(randomName))
+		}
+	} else if serverConfig != nil && serverConfig.Name != "" {
+		fmt.Printf("Automation server: %s (%s)\n", serverConfig.Name, serverConfig.Slug)
+	}
+
 	// Check if container already exists
 	checkCmd := exec.Command("docker", "ps", "-a", "--filter", "name=bitswan-automation-server-daemon", "--format", "{{.Names}}")
 	output, err := checkCmd.Output()

--- a/cmd/ingress/list_routes.go
+++ b/cmd/ingress/list_routes.go
@@ -9,13 +9,22 @@ import (
 )
 
 func newListRoutesCmd() *cobra.Command {
+	var target string
+
 	cmd := &cobra.Command{
 		Use:   "list-routes",
 		Short: "List all configured routes",
 		Long: `List all routes currently configured in the ingress proxy.
 
+When VPN is enabled, use --target to filter by ingress:
+  --target external   Show only internet-facing routes
+  --target internal   Show only VPN-internal routes
+  (no flag)           Show all routes from both ingresses
+
 Examples:
-  bitswan ingress list-routes`,
+  bitswan ingress list-routes
+  bitswan ingress list-routes --target external
+  bitswan ingress list-routes --target internal`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := daemon.NewClient()
@@ -25,28 +34,61 @@ Examples:
 				os.Exit(1)
 			}
 
-			result, err := client.ListIngressRoutes()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+			// List external routes
+			showExternal := target == "" || target == "external"
+			showInternal := target == "" || target == "internal"
+
+			totalRoutes := 0
+
+			if showExternal {
+				result, err := client.ListIngressRoutes()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error listing external routes: %v\n", err)
+					os.Exit(1)
+				}
+				if len(result.Routes) > 0 {
+					if target == "" {
+						fmt.Printf("=== External Ingress (%d routes) ===\n\n", len(result.Routes))
+					}
+					for _, route := range result.Routes {
+						fmt.Printf("  %s → %s\n", route.Hostname, route.Upstream)
+					}
+					if target == "" {
+						fmt.Println()
+					}
+					totalRoutes += len(result.Routes)
+				}
 			}
 
-			if len(result.Routes) == 0 {
+			if showInternal && daemon.IsVPNEnabled() {
+				result, err := client.ListVPNIngressRoutes()
+				if err != nil {
+					// VPN Traefik might not be running
+					if target == "internal" {
+						fmt.Fprintf(os.Stderr, "Error listing VPN routes: %v\n", err)
+						os.Exit(1)
+					}
+				} else if len(result.Routes) > 0 {
+					if target == "" {
+						fmt.Printf("=== VPN Ingress (%d routes) ===\n\n", len(result.Routes))
+					}
+					for _, route := range result.Routes {
+						fmt.Printf("  %s → %s\n", route.Hostname, route.Upstream)
+					}
+					fmt.Println()
+					totalRoutes += len(result.Routes)
+				}
+			}
+
+			if totalRoutes == 0 {
 				fmt.Println("No routes configured")
-				return nil
-			}
-
-			fmt.Printf("Found %d route(s):\n\n", len(result.Routes))
-			for _, route := range result.Routes {
-				fmt.Printf("Route ID: %s\n", route.ID)
-				fmt.Printf("  Hostname: %s\n", route.Hostname)
-				fmt.Printf("  Upstream: %s\n", route.Upstream)
-				fmt.Printf("  Terminal: %t\n\n", route.Terminal)
 			}
 
 			return nil
 		},
 	}
 
+	cmd.Flags().StringVar(&target, "target", "", "Filter by ingress: 'external' or 'internal'")
+
 	return cmd
-} 
+}

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -66,7 +66,6 @@ func newRegisterCmd() *cobra.Command {
 			}
 
 			// Update the server name from AOC (replaces the random name from init)
-			cfg := config.NewAutomationServerConfig()
 			if serverInfo.Name != "" {
 				if err := cfg.SetNameAndSlug(serverInfo.Name); err != nil {
 					fmt.Printf("Warning: failed to update server name: %v\n", err)

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -64,6 +64,14 @@ func newRegisterCmd() *cobra.Command {
 				return fmt.Errorf("failed to save configuration: %w", err)
 			}
 
+			// Update the server name from AOC (replaces the random name from init)
+			if serverInfo.Name != "" {
+				cfg := config.NewAutomationServerConfig()
+				if err := cfg.SetNameAndSlug(serverInfo.Name); err != nil {
+					fmt.Printf("Warning: failed to update server name: %v\n", err)
+				}
+			}
+
 			fmt.Printf("✅ Successfully registered automation server '%s' with ID: %s\n", serverInfo.Name, serverInfo.AutomationServerId)
 			fmt.Println("Access token, AOC URL, and Automation server ID have been saved to ~/.config/bitswan/automation_server_config.toml.")
 

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/aoc"
 	"github.com/bitswan-space/bitswan-workspaces/internal/config"
@@ -65,10 +66,29 @@ func newRegisterCmd() *cobra.Command {
 			}
 
 			// Update the server name from AOC (replaces the random name from init)
+			cfg := config.NewAutomationServerConfig()
 			if serverInfo.Name != "" {
-				cfg := config.NewAutomationServerConfig()
 				if err := cfg.SetNameAndSlug(serverInfo.Name); err != nil {
 					fmt.Printf("Warning: failed to update server name: %v\n", err)
+				}
+			}
+
+			// Try to set platform domain from existing workspaces
+			serverCfg, _ := cfg.LoadConfig()
+			if serverCfg != nil && serverCfg.Domain == "" {
+				homeDir, _ := os.UserHomeDir()
+				workspacesDir := homeDir + "/.config/bitswan/workspaces"
+				if entries, err := os.ReadDir(workspacesDir); err == nil {
+					for _, entry := range entries {
+						if !entry.IsDir() {
+							continue
+						}
+						if meta, err := config.GetWorkspaceMetadata(entry.Name()); err == nil && meta.Domain != "" {
+							cfg.SetDomain(meta.Domain)
+							fmt.Printf("Platform domain set to: %s\n", meta.Domain)
+							break
+						}
+					}
 				}
 			}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bitswan-space/bitswan-workspaces/cmd/certauthority"
 	"github.com/bitswan-space/bitswan-workspaces/cmd/ingress"
 	"github.com/bitswan-space/bitswan-workspaces/cmd/test"
+	"github.com/bitswan-space/bitswan-workspaces/cmd/vpn"
 	"github.com/spf13/cobra"
 )
 
@@ -63,6 +64,7 @@ func newRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(automationserverdaemon.NewAutomationServerDaemonCmd())     // automation server daemon subcommand
 	cmd.AddCommand(automation.NewAutomationCmd())                             // automation subcommand
 	cmd.AddCommand(test.NewTestCmd())                                         // _test subcommand (hidden)
+	cmd.AddCommand(vpn.NewVPNCmd())                                          // vpn subcommand
 	cmd.AddCommand(newCompletionCmd())                                        // completion subcommand
 
 	// Set the version for the daemon server

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -58,7 +58,13 @@ The server name is set during 'bitswan automation-server-daemon init'
 (random Docker-style name) or when registering with the AOC.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if endpoint == "" {
-				return fmt.Errorf("--endpoint is required (e.g., vpn.example.com or 203.0.113.1)")
+				// Auto-detect public IP
+				detected, err := detectPublicIP()
+				if err != nil {
+					return fmt.Errorf("could not detect public IP (use --endpoint to set manually): %w", err)
+				}
+				endpoint = detected
+				fmt.Printf("Detected public IP: %s\n", endpoint)
 			}
 
 			// Load existing config to get the server slug
@@ -98,7 +104,7 @@ The server name is set during 'bitswan automation-server-daemon init'
 		},
 	}
 
-	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Public hostname or IP for VPN connections (required)")
+	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Public hostname or IP for VPN connections (auto-detected if omitted)")
 
 	return cmd
 }
@@ -337,4 +343,21 @@ func printConnectionGuide(confPath string) {
 	fmt.Println()
 	fmt.Println("  If you can ping the gateway, your VPN is working and you can")
 	fmt.Println("  access the editor, gitops, and dev automations through the VPN.")
+}
+
+func detectPublicIP() (string, error) {
+	resp, err := http.Get("https://api.ipify.org")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	ip := strings.TrimSpace(string(body))
+	if ip == "" {
+		return "", fmt.Errorf("empty response from IP detection service")
+	}
+	return ip, nil
 }

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -1,0 +1,211 @@
+package vpn
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+func NewVPNCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vpn",
+		Short: "Manage WireGuard VPN for the platform",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newStatusCmd())
+	cmd.AddCommand(newListUsersCmd())
+	cmd.AddCommand(newGenerateCredsCmd())
+	cmd.AddCommand(newRevokeCmd())
+
+	return cmd
+}
+
+func getDaemonClient() *daemon.Client {
+	client, err := daemon.NewClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Run 'bitswan automation-server-daemon init' to start it.")
+		os.Exit(1)
+	}
+	return client
+}
+
+func newInitCmd() *cobra.Command {
+	var endpoint string
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize WireGuard VPN for the platform",
+		Long:  "Sets up the WireGuard server, VPN network, and VPN Traefik. All workspaces will use this VPN.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if endpoint == "" {
+				return fmt.Errorf("--endpoint is required (e.g., vpn.example.com or 203.0.113.1)")
+			}
+
+			client := getDaemonClient()
+			body := fmt.Sprintf(`{"endpoint": %q}`, endpoint)
+			req, err := http.NewRequest("POST", "http://daemon/vpn/init", strings.NewReader(body))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return fmt.Errorf("failed to initialize VPN: %w", err)
+			}
+			defer resp.Body.Close()
+
+			var result map[string]string
+			json.NewDecoder(resp.Body).Decode(&result)
+			fmt.Println(result["message"])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Public hostname or IP for VPN connections (required)")
+
+	return cmd
+}
+
+func newStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show VPN status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := getDaemonClient()
+			req, _ := http.NewRequest("GET", "http://daemon/vpn/status", nil)
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			var status map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&status)
+
+			initialized, _ := status["initialized"].(bool)
+			if !initialized {
+				fmt.Println("VPN: not initialized")
+				fmt.Println("Run 'bitswan vpn init --endpoint <hostname>' to set up")
+				return nil
+			}
+
+			enabled, _ := status["enabled"].(bool)
+			if enabled {
+				fmt.Println("VPN: enabled")
+			} else {
+				fmt.Println("VPN: disabled")
+			}
+			if pub, ok := status["server_public_key"].(string); ok {
+				fmt.Printf("Server public key: %s\n", pub)
+			}
+			if count, ok := status["user_count"].(float64); ok {
+				fmt.Printf("Users: %d\n", int(count))
+			}
+			return nil
+		},
+	}
+}
+
+func newListUsersCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-users",
+		Short: "List VPN users",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := getDaemonClient()
+			req, _ := http.NewRequest("GET", "http://daemon/vpn/users", nil)
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			var users []map[string]string
+			json.NewDecoder(resp.Body).Decode(&users)
+
+			if len(users) == 0 {
+				fmt.Println("No VPN users.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "USER ID\tIP\tPUBLIC KEY")
+			for _, u := range users {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", u["id"], u["ip"], u["public_key"])
+			}
+			w.Flush()
+			return nil
+		},
+	}
+}
+
+func newGenerateCredsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "generate-credentials <user-id>",
+		Short: "Generate VPN credentials for a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			userID := args[0]
+			client := getDaemonClient()
+			body := fmt.Sprintf(`{"user_id": %q}`, userID)
+			req, err := http.NewRequest("POST", "http://daemon/vpn/credentials", strings.NewReader(body))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			outPath := userID + ".conf"
+			f, err := os.Create(outPath)
+			if err != nil {
+				return fmt.Errorf("failed to create %s: %w", outPath, err)
+			}
+			defer f.Close()
+			io.Copy(f, resp.Body)
+
+			fmt.Printf("VPN config written to %s\n", outPath)
+			return nil
+		},
+	}
+}
+
+func newRevokeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke <user-id>",
+		Short: "Revoke VPN access for a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			userID := args[0]
+			client := getDaemonClient()
+			body := fmt.Sprintf(`{"user_id": %q}`, userID)
+			req, err := http.NewRequest("POST", "http://daemon/vpn/revoke", strings.NewReader(body))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			fmt.Printf("Revoked VPN access for %s\n", userID)
+			return nil
+		},
+	}
+}

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/user"
 	"strings"
 	"text/tabwriter"
 
@@ -23,9 +24,10 @@ func NewVPNCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newBootstrapCmd())
+	cmd.AddCommand(newInviteCmd())
 	cmd.AddCommand(newStatusCmd())
 	cmd.AddCommand(newListUsersCmd())
-	cmd.AddCommand(newGenerateCredsCmd())
 	cmd.AddCommand(newRevokeCmd())
 
 	return cmd
@@ -69,6 +71,8 @@ func newInitCmd() *cobra.Command {
 			var result map[string]string
 			json.NewDecoder(resp.Body).Decode(&result)
 			fmt.Println(result["message"])
+			fmt.Println()
+			fmt.Println("Next step: run 'bitswan vpn bootstrap' to generate your admin VPN config.")
 			return nil
 		},
 	}
@@ -76,6 +80,93 @@ func newInitCmd() *cobra.Command {
 	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Public hostname or IP for VPN connections (required)")
 
 	return cmd
+}
+
+func newBootstrapCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Generate your VPN config (first admin)",
+		Long: `Generate a WireGuard VPN configuration for yourself as the first administrator.
+
+This is only for initial setup. To give VPN access to other users,
+use 'bitswan vpn invite' to generate a magic link instead.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Use system username as the user ID
+			u, err := user.Current()
+			if err != nil {
+				return fmt.Errorf("failed to get current user: %w", err)
+			}
+			userID := u.Username
+
+			client := getDaemonClient()
+			body := fmt.Sprintf(`{"user_id": %q}`, userID)
+			req, err := http.NewRequest("POST", "http://daemon/vpn/credentials", strings.NewReader(body))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return fmt.Errorf("failed to generate credentials: %w", err)
+			}
+			defer resp.Body.Close()
+
+			outPath := "wireguard.conf"
+			f, err := os.Create(outPath)
+			if err != nil {
+				return fmt.Errorf("failed to create %s: %w", outPath, err)
+			}
+			defer f.Close()
+			io.Copy(f, resp.Body)
+
+			fmt.Printf("VPN config written to %s\n\n", outPath)
+			printConnectionGuide(outPath)
+			return nil
+		},
+	}
+}
+
+func newInviteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "invite",
+		Short: "Generate a magic link to invite a user to the VPN",
+		Long: `Generate a one-time magic link (valid 1 hour) that you can send to
+a colleague. They open the link, authenticate via OAuth, and their
+VPN config is generated automatically using their email as the user ID.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u, _ := user.Current()
+			createdBy := u.Username
+
+			client := getDaemonClient()
+			body := fmt.Sprintf(`{"created_by": %q}`, createdBy)
+			req, err := http.NewRequest("POST", "http://daemon/vpn/magic-link", strings.NewReader(body))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return fmt.Errorf("failed to create magic link: %w", err)
+			}
+			defer resp.Body.Close()
+
+			var result map[string]string
+			json.NewDecoder(resp.Body).Decode(&result)
+
+			fmt.Println("Magic link created!")
+			fmt.Println()
+			fmt.Printf("  Link:    %s\n", result["claim_url"])
+			fmt.Printf("  Expires: %s\n", result["expires"])
+			fmt.Println()
+			fmt.Println("Send this link to the user. They will:")
+			fmt.Println("  1. Open the link in their browser")
+			fmt.Println("  2. Authenticate with their organization credentials (OAuth)")
+			fmt.Println("  3. Download their personal WireGuard config")
+			fmt.Println()
+			fmt.Println("The link can only be used once and expires in 1 hour.")
+			return nil
+		},
+	}
 }
 
 func newStatusCmd() *cobra.Command {
@@ -140,7 +231,7 @@ func newListUsersCmd() *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "USER ID\tIP\tPUBLIC KEY")
+			fmt.Fprintln(w, "USER\tIP\tPUBLIC KEY")
 			for _, u := range users {
 				fmt.Fprintf(w, "%s\t%s\t%s\n", u["id"], u["ip"], u["public_key"])
 			}
@@ -150,44 +241,11 @@ func newListUsersCmd() *cobra.Command {
 	}
 }
 
-func newGenerateCredsCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "generate-credentials <user-id>",
-		Short: "Generate VPN credentials for a user",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			userID := args[0]
-			client := getDaemonClient()
-			body := fmt.Sprintf(`{"user_id": %q}`, userID)
-			req, err := http.NewRequest("POST", "http://daemon/vpn/credentials", strings.NewReader(body))
-			if err != nil {
-				return err
-			}
-			req.Header.Set("Content-Type", "application/json")
-			resp, err := client.DoRequest(req)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-
-			outPath := userID + ".conf"
-			f, err := os.Create(outPath)
-			if err != nil {
-				return fmt.Errorf("failed to create %s: %w", outPath, err)
-			}
-			defer f.Close()
-			io.Copy(f, resp.Body)
-
-			fmt.Printf("VPN config written to %s\n", outPath)
-			return nil
-		},
-	}
-}
-
 func newRevokeCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "revoke <user-id>",
+		Use:   "revoke <user>",
 		Short: "Revoke VPN access for a user",
+		Long:  "Revoke a user's VPN access. Use 'bitswan vpn list-users' to see user IDs.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			userID := args[0]
@@ -208,4 +266,54 @@ func newRevokeCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func printConnectionGuide(confPath string) {
+	fmt.Println("=== WireGuard Connection Guide ===")
+	fmt.Println()
+	fmt.Println("--- Linux ---")
+	fmt.Println()
+	fmt.Println("  Install WireGuard:")
+	fmt.Println("    Ubuntu/Debian:  sudo apt install wireguard")
+	fmt.Println("    Fedora:         sudo dnf install wireguard-tools")
+	fmt.Println("    Arch:           sudo pacman -S wireguard-tools")
+	fmt.Println()
+	fmt.Printf("  Copy the config and start the tunnel:\n")
+	fmt.Printf("    sudo cp %s /etc/wireguard/wg0.conf\n", confPath)
+	fmt.Println("    sudo wg-quick up wg0")
+	fmt.Println()
+	fmt.Println("  To connect automatically on boot:")
+	fmt.Println("    sudo systemctl enable --now wg-quick@wg0")
+	fmt.Println()
+	fmt.Println("  To disconnect:")
+	fmt.Println("    sudo wg-quick down wg0")
+	fmt.Println()
+	fmt.Println("  Check connection status:")
+	fmt.Println("    sudo wg show")
+	fmt.Println()
+	fmt.Println("--- macOS ---")
+	fmt.Println()
+	fmt.Println("  Option 1: WireGuard App (recommended)")
+	fmt.Println("    1. Install WireGuard from the Mac App Store")
+	fmt.Printf("    2. Open the app → \"Import Tunnel(s) from File\" → select %s\n", confPath)
+	fmt.Println("    3. Click \"Activate\" to connect")
+	fmt.Println()
+	fmt.Println("  Option 2: Command line (Homebrew)")
+	fmt.Println("    brew install wireguard-tools")
+	fmt.Printf("    sudo cp %s /etc/wireguard/wg0.conf\n", confPath)
+	fmt.Println("    sudo wg-quick up wg0")
+	fmt.Println()
+	fmt.Println("--- Windows ---")
+	fmt.Println()
+	fmt.Println("  1. Download WireGuard from https://www.wireguard.com/install/")
+	fmt.Printf("  2. Open the app → \"Import tunnel(s) from file\" → select %s\n", confPath)
+	fmt.Println("  3. Click \"Activate\" to connect")
+	fmt.Println()
+	fmt.Println("--- Verify Connection ---")
+	fmt.Println()
+	fmt.Println("  After connecting, verify you can reach the internal services:")
+	fmt.Println("    ping 10.8.0.1    (VPN gateway)")
+	fmt.Println()
+	fmt.Println("  If you can ping the gateway, your VPN is working and you can")
+	fmt.Println("  access the editor, gitops, and dev automations through the VPN.")
 }

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -130,6 +130,14 @@ use 'bitswan vpn invite' to generate a magic link instead.`,
 			}
 			userID := u.Username
 
+			// Get the server slug for the filename
+			cfg := config.NewAutomationServerConfig()
+			serverConfig, _ := cfg.LoadConfig()
+			slug := "wireguard"
+			if serverConfig != nil && serverConfig.Slug != "" {
+				slug = serverConfig.Slug
+			}
+
 			client := getDaemonClient()
 			body := fmt.Sprintf(`{"user_id": %q}`, userID)
 			req, err := http.NewRequest("POST", "http://daemon/vpn/credentials", strings.NewReader(body))
@@ -143,7 +151,7 @@ use 'bitswan vpn invite' to generate a magic link instead.`,
 			}
 			defer resp.Body.Close()
 
-			outPath := "wireguard.conf"
+			outPath := slug + ".conf"
 			f, err := os.Create(outPath)
 			if err != nil {
 				return fmt.Errorf("failed to create %s: %w", outPath, err)
@@ -152,7 +160,7 @@ use 'bitswan vpn invite' to generate a magic link instead.`,
 			io.Copy(f, resp.Body)
 
 			fmt.Printf("VPN config written to %s\n\n", outPath)
-			printConnectionGuide(outPath)
+			printConnectionGuide(outPath, slug)
 			return nil
 		},
 	}
@@ -300,7 +308,7 @@ func newRevokeCmd() *cobra.Command {
 	}
 }
 
-func printConnectionGuide(confPath string) {
+func printConnectionGuide(confPath, slug string) {
 	fmt.Println("=== WireGuard Connection Guide ===")
 	fmt.Println()
 	fmt.Println("--- Linux ---")
@@ -311,14 +319,14 @@ func printConnectionGuide(confPath string) {
 	fmt.Println("    Arch:           sudo pacman -S wireguard-tools")
 	fmt.Println()
 	fmt.Printf("  Copy the config and start the tunnel:\n")
-	fmt.Printf("    sudo cp %s /etc/wireguard/wg0.conf\n", confPath)
-	fmt.Println("    sudo wg-quick up wg0")
+	fmt.Printf("    sudo cp %s /etc/wireguard/%s.conf\n", confPath, slug)
+	fmt.Printf("    sudo wg-quick up %s\n", slug)
 	fmt.Println()
 	fmt.Println("  To connect automatically on boot:")
-	fmt.Println("    sudo systemctl enable --now wg-quick@wg0")
+	fmt.Printf("    sudo systemctl enable --now wg-quick@%s\n", slug)
 	fmt.Println()
 	fmt.Println("  To disconnect:")
-	fmt.Println("    sudo wg-quick down wg0")
+	fmt.Printf("    sudo wg-quick down %s\n", slug)
 	fmt.Println()
 	fmt.Println("  Check connection status:")
 	fmt.Println("    sudo wg show")
@@ -332,8 +340,8 @@ func printConnectionGuide(confPath string) {
 	fmt.Println()
 	fmt.Println("  Option 2: Command line (Homebrew)")
 	fmt.Println("    brew install wireguard-tools")
-	fmt.Printf("    sudo cp %s /etc/wireguard/wg0.conf\n", confPath)
-	fmt.Println("    sudo wg-quick up wg0")
+	fmt.Printf("    sudo cp %s /etc/wireguard/%s.conf\n", confPath, slug)
+	fmt.Printf("    sudo wg-quick up %s\n", slug)
 	fmt.Println()
 	fmt.Println("--- Windows ---")
 	fmt.Println()

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -31,6 +31,7 @@ func NewVPNCmd() *cobra.Command {
 	cmd.AddCommand(newInviteCmd())
 	cmd.AddCommand(newStatusCmd())
 	cmd.AddCommand(newListDevicesCmd())
+	cmd.AddCommand(newSessionsCmd())
 	cmd.AddCommand(newRevokeCmd())
 
 	return cmd
@@ -355,6 +356,91 @@ func newListDevicesCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newSessionsCmd() *cobra.Command {
+	var active bool
+
+	cmd := &cobra.Command{
+		Use:   "sessions",
+		Short: "Show VPN session history and active connections",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := getDaemonClient()
+			url := "http://daemon/vpn/sessions"
+			if active {
+				url += "?active=true"
+			}
+			req, _ := http.NewRequest("GET", url, nil)
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			var events []map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&events)
+
+			if len(events) == 0 {
+				if active {
+					fmt.Println("No active VPN sessions.")
+				} else {
+					fmt.Println("No VPN session history.")
+				}
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			if active {
+				fmt.Fprintln(w, "DEVICE\tUSER\tIP\tRX\tTX\tLAST SEEN")
+				for _, e := range events {
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+						str(e, "device_name"), str(e, "user_id"), str(e, "ip"),
+						humanBytes(num(e, "transfer_rx")), humanBytes(num(e, "transfer_tx")),
+						str(e, "timestamp"))
+				}
+			} else {
+				fmt.Fprintln(w, "TIME\tEVENT\tDEVICE\tUSER\tSOURCE IP")
+				for _, e := range events {
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+						str(e, "timestamp"), str(e, "event"),
+						str(e, "device_name"), str(e, "user_id"),
+						str(e, "source_ip"))
+				}
+			}
+			w.Flush()
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&active, "active", false, "Show only currently active sessions")
+	return cmd
+}
+
+func str(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func num(m map[string]interface{}, key string) int64 {
+	if v, ok := m[key].(float64); ok {
+		return int64(v)
+	}
+	return 0
+}
+
+func humanBytes(b int64) string {
+	if b < 1024 {
+		return fmt.Sprintf("%d B", b)
+	}
+	if b < 1024*1024 {
+		return fmt.Sprintf("%.1f KiB", float64(b)/1024)
+	}
+	if b < 1024*1024*1024 {
+		return fmt.Sprintf("%.1f MiB", float64(b)/(1024*1024))
+	}
+	return fmt.Sprintf("%.1f GiB", float64(b)/(1024*1024*1024))
 }
 
 func newRevokeCmd() *cobra.Command {

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -74,7 +74,12 @@ The server name is set during 'bitswan automation-server-daemon init'
 				return fmt.Errorf("automation server not initialized — run 'bitswan automation-server-daemon init' first")
 			}
 			if serverConfig.Slug == "" {
-				return fmt.Errorf("automation server has no name — this should have been set during init")
+				randomName := config.GenerateRandomName()
+				if err := cfg.SetNameAndSlug(randomName); err != nil {
+					return fmt.Errorf("failed to generate server name: %w", err)
+				}
+				serverConfig, _ = cfg.LoadConfig()
+				fmt.Printf("Generated server name: %s\n", randomName)
 			}
 			internalDomain := serverConfig.InternalDomain()
 

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 
@@ -47,6 +48,7 @@ func getDaemonClient() *daemon.Client {
 
 func newInitCmd() *cobra.Command {
 	var endpoint string
+	var domain string
 
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -82,6 +84,28 @@ The server name is set during 'bitswan automation-server-daemon init'
 				serverConfig, _ = cfg.LoadConfig()
 				fmt.Printf("Generated server name: %s\n", randomName)
 			}
+
+			// Resolve platform domain
+			if domain != "" {
+				// Flag provided — save to config
+				if err := cfg.SetDomain(domain); err != nil {
+					return fmt.Errorf("failed to save domain: %w", err)
+				}
+				serverConfig, _ = cfg.LoadConfig()
+			} else if serverConfig.Domain == "" {
+				// Try to find domain from an existing workspace
+				foundDomain := findDomainFromWorkspaces()
+				if foundDomain != "" {
+					fmt.Printf("Detected domain from existing workspace: %s\n", foundDomain)
+					if err := cfg.SetDomain(foundDomain); err != nil {
+						return fmt.Errorf("failed to save domain: %w", err)
+					}
+					serverConfig, _ = cfg.LoadConfig()
+				} else {
+					return fmt.Errorf("no domain configured. Use --domain or register with AOC first")
+				}
+			}
+
 			internalDomain := serverConfig.InternalDomain()
 
 			client := getDaemonClient()
@@ -116,6 +140,7 @@ The server name is set during 'bitswan automation-server-daemon init'
 	}
 
 	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Public hostname or IP for VPN connections (auto-detected if omitted)")
+	cmd.Flags().StringVar(&domain, "domain", "", "Platform domain (e.g., sandbox.bitswan.ai) — auto-detected from workspaces if omitted")
 
 	return cmd
 }
@@ -392,6 +417,29 @@ func printConnectionGuide(confPath, slug string) {
 	fmt.Println()
 	fmt.Println("  If you can ping the gateway, your VPN is working and you can")
 	fmt.Println("  access the editor, gitops, and dev automations through the VPN.")
+}
+
+// findDomainFromWorkspaces scans existing workspace metadata for a domain.
+func findDomainFromWorkspaces() string {
+	homeDir, _ := os.UserHomeDir()
+	workspacesDir := filepath.Join(homeDir, ".config", "bitswan", "workspaces")
+	entries, err := os.ReadDir(workspacesDir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		meta, err := config.GetWorkspaceMetadata(entry.Name())
+		if err != nil {
+			continue
+		}
+		if meta.Domain != "" {
+			return meta.Domain
+		}
+	}
+	return ""
 }
 
 func detectPublicIP() (string, error) {

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -30,7 +30,7 @@ func NewVPNCmd() *cobra.Command {
 	cmd.AddCommand(newBootstrapCmd())
 	cmd.AddCommand(newInviteCmd())
 	cmd.AddCommand(newStatusCmd())
-	cmd.AddCommand(newListUsersCmd())
+	cmd.AddCommand(newListDevicesCmd())
 	cmd.AddCommand(newRevokeCmd())
 
 	return cmd
@@ -176,22 +176,32 @@ func newDestroyCmd() *cobra.Command {
 }
 
 func newBootstrapCmd() *cobra.Command {
-	return &cobra.Command{
+	var deviceName string
+
+	cmd := &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Generate your VPN config (first admin)",
 		Long: `Generate a WireGuard VPN configuration for yourself as the first administrator.
 
-This is only for initial setup. To give VPN access to other users,
-use 'bitswan vpn invite' to generate a magic link instead.`,
+Use --device to name this device (e.g., "laptop", "desktop").
+You can run bootstrap multiple times with different device names.
+
+To give VPN access to other users, use 'bitswan vpn invite' instead.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Use system username as the user ID
 			u, err := user.Current()
 			if err != nil {
 				return fmt.Errorf("failed to get current user: %w", err)
 			}
 			userID := u.Username
+			if deviceName == "" {
+				hostname, _ := os.Hostname()
+				if hostname != "" {
+					deviceName = hostname
+				} else {
+					deviceName = "default"
+				}
+			}
 
-			// Get the server slug for the filename
 			cfg := config.NewAutomationServerConfig()
 			serverConfig, _ := cfg.LoadConfig()
 			slug := "wireguard"
@@ -200,7 +210,7 @@ use 'bitswan vpn invite' to generate a magic link instead.`,
 			}
 
 			client := getDaemonClient()
-			body := fmt.Sprintf(`{"user_id": %q}`, userID)
+			body := fmt.Sprintf(`{"user_id": %q, "device_name": %q}`, userID, deviceName)
 			req, err := http.NewRequest("POST", "http://daemon/vpn/credentials", strings.NewReader(body))
 			if err != nil {
 				return err
@@ -220,11 +230,15 @@ use 'bitswan vpn invite' to generate a magic link instead.`,
 			defer f.Close()
 			io.Copy(f, resp.Body)
 
-			fmt.Printf("VPN config written to %s\n\n", outPath)
+			fmt.Printf("VPN config written to %s (device: %s/%s)\n\n", outPath, userID, deviceName)
 			printConnectionGuide(outPath, slug)
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&deviceName, "device", "", "Device name (e.g., 'laptop', 'phone') — defaults to hostname")
+
+	return cmd
 }
 
 func newInviteCmd() *cobra.Command {
@@ -310,10 +324,10 @@ func newStatusCmd() *cobra.Command {
 	}
 }
 
-func newListUsersCmd() *cobra.Command {
+func newListDevicesCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list-users",
-		Short: "List VPN users",
+		Use:   "list-devices",
+		Short: "List all VPN devices",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := getDaemonClient()
 			req, _ := http.NewRequest("GET", "http://daemon/vpn/users", nil)
@@ -323,18 +337,19 @@ func newListUsersCmd() *cobra.Command {
 			}
 			defer resp.Body.Close()
 
-			var users []map[string]string
-			json.NewDecoder(resp.Body).Decode(&users)
+			var devices []map[string]string
+			json.NewDecoder(resp.Body).Decode(&devices)
 
-			if len(users) == 0 {
-				fmt.Println("No VPN users.")
+			if len(devices) == 0 {
+				fmt.Println("No VPN devices.")
 				return nil
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "USER\tIP\tPUBLIC KEY")
-			for _, u := range users {
-				fmt.Fprintf(w, "%s\t%s\t%s\n", u["id"], u["ip"], u["public_key"])
+			fmt.Fprintln(w, "DEVICE ID\tUSER\tDEVICE\tIP\tISSUED")
+			for _, d := range devices {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+					d["device_id"], d["user_id"], d["device_name"], d["ip"], d["issued_at"])
 			}
 			w.Flush()
 			return nil
@@ -344,14 +359,14 @@ func newListUsersCmd() *cobra.Command {
 
 func newRevokeCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "revoke <user>",
-		Short: "Revoke VPN access for a user",
-		Long:  "Revoke a user's VPN access. Use 'bitswan vpn list-users' to see user IDs.",
+		Use:   "revoke <user/device>",
+		Short: "Revoke a VPN device",
+		Long:  "Revoke a specific device's VPN access. Use 'bitswan vpn list-devices' to see device IDs.\nFormat: user/device (e.g., admin/laptop)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			userID := args[0]
+			deviceID := args[0]
 			client := getDaemonClient()
-			body := fmt.Sprintf(`{"user_id": %q}`, userID)
+			body := fmt.Sprintf(`{"device_id": %q}`, deviceID)
 			req, err := http.NewRequest("POST", "http://daemon/vpn/revoke", strings.NewReader(body))
 			if err != nil {
 				return err
@@ -363,7 +378,7 @@ func newRevokeCmd() *cobra.Command {
 			}
 			defer resp.Body.Close()
 
-			fmt.Printf("Revoked VPN access for %s\n", userID)
+			fmt.Printf("Revoked VPN device %s\n", deviceID)
 			return nil
 		},
 	}

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -97,8 +97,13 @@ The server name is set during 'bitswan automation-server-daemon init'
 			}
 			defer resp.Body.Close()
 
+			respBody, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("VPN init failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+			}
+
 			var result map[string]string
-			json.NewDecoder(resp.Body).Decode(&result)
+			json.Unmarshal(respBody, &result)
 			fmt.Println(result["message"])
 			fmt.Println()
 			fmt.Printf("Automation server: %s (slug: %s)\n", serverConfig.Name, serverConfig.Slug)

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/bitswan-space/bitswan-workspaces/internal/config"
 	"github.com/bitswan-space/bitswan-workspaces/internal/daemon"
 	"github.com/spf13/cobra"
 )
@@ -49,14 +50,30 @@ func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize WireGuard VPN for the platform",
-		Long:  "Sets up the WireGuard server, VPN network, and VPN Traefik. All workspaces will use this VPN.",
+		Long: `Sets up the WireGuard server, VPN DNS, and VPN Traefik.
+All workspaces will use this VPN.
+
+Internal services use a fake TLD: <workspace>.<server-slug>.bswn.internal
+The server name is set during 'bitswan automation-server-daemon init'
+(random Docker-style name) or when registering with the AOC.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if endpoint == "" {
 				return fmt.Errorf("--endpoint is required (e.g., vpn.example.com or 203.0.113.1)")
 			}
 
+			// Load existing config to get the server slug
+			cfg := config.NewAutomationServerConfig()
+			serverConfig, err := cfg.LoadConfig()
+			if err != nil {
+				return fmt.Errorf("automation server not initialized — run 'bitswan automation-server-daemon init' first")
+			}
+			if serverConfig.Slug == "" {
+				return fmt.Errorf("automation server has no name — this should have been set during init")
+			}
+			internalDomain := serverConfig.InternalDomain()
+
 			client := getDaemonClient()
-			body := fmt.Sprintf(`{"endpoint": %q}`, endpoint)
+			body := fmt.Sprintf(`{"endpoint": %q, "internal_domain": %q}`, endpoint, internalDomain)
 			req, err := http.NewRequest("POST", "http://daemon/vpn/init", strings.NewReader(body))
 			if err != nil {
 				return err
@@ -71,6 +88,10 @@ func newInitCmd() *cobra.Command {
 			var result map[string]string
 			json.NewDecoder(resp.Body).Decode(&result)
 			fmt.Println(result["message"])
+			fmt.Println()
+			fmt.Printf("Automation server: %s (slug: %s)\n", serverConfig.Name, serverConfig.Slug)
+			fmt.Printf("Internal domain:   *.%s\n", internalDomain)
+			fmt.Printf("Workspace URLs:    <workspace>.%s\n", internalDomain)
 			fmt.Println()
 			fmt.Println("Next step: run 'bitswan vpn bootstrap' to generate your admin VPN config.")
 			return nil

--- a/cmd/vpn/root.go
+++ b/cmd/vpn/root.go
@@ -25,6 +25,7 @@ func NewVPNCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newDestroyCmd())
 	cmd.AddCommand(newBootstrapCmd())
 	cmd.AddCommand(newInviteCmd())
 	cmd.AddCommand(newStatusCmd())
@@ -112,6 +113,36 @@ The server name is set during 'bitswan automation-server-daemon init'
 	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Public hostname or IP for VPN connections (auto-detected if omitted)")
 
 	return cmd
+}
+
+func newDestroyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "destroy",
+		Short: "Tear down VPN infrastructure",
+		Long:  "Stop and remove all VPN containers (WireGuard, VPN Traefik, CoreDNS) and delete VPN config.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := getDaemonClient()
+			req, err := http.NewRequest("POST", "http://daemon/vpn/destroy", nil)
+			if err != nil {
+				return err
+			}
+			resp, err := client.DoRequest(req)
+			if err != nil {
+				return fmt.Errorf("failed to destroy VPN: %w", err)
+			}
+			defer resp.Body.Close()
+
+			var result map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&result)
+			fmt.Println(result["message"])
+			if errs, ok := result["errors"].([]interface{}); ok {
+				for _, e := range errs {
+					fmt.Printf("  Warning: %v\n", e)
+				}
+			}
+			return nil
+		},
+	}
 }
 
 func newBootstrapCmd() *cobra.Command {

--- a/internal/config/automationserverconfig.go
+++ b/internal/config/automationserverconfig.go
@@ -33,6 +33,7 @@ type Config struct {
 	ActiveWorkspace            string                             `toml:"active_workspace"`
 	Name                       string                             `toml:"name,omitempty"`
 	Slug                       string                             `toml:"slug,omitempty"`
+	Domain                     string                             `toml:"domain,omitempty"`
 	AutomationOperationsCenter AutomationOperationsCenterSettings `toml:"aoc"`
 	LocalServer                LocalServerSettings                `toml:"local_server"`
 }
@@ -164,6 +165,16 @@ func (m *AutomationServerConfig) SetNameAndSlug(name string) error {
 	}
 	config.Name = name
 	config.Slug = Slugify(name)
+	return m.SaveConfig(config)
+}
+
+// SetDomain sets the platform-level domain (e.g., sandbox.bitswan.ai).
+func (m *AutomationServerConfig) SetDomain(domain string) error {
+	config, err := m.LoadConfig()
+	if err != nil {
+		config = &Config{}
+	}
+	config.Domain = domain
 	return m.SaveConfig(config)
 }
 

--- a/internal/config/automationserverconfig.go
+++ b/internal/config/automationserverconfig.go
@@ -5,9 +5,23 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
+
+// Slugify converts a name to a DNS-safe slug (lowercase, hyphens, no leading/trailing hyphens).
+func Slugify(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = regexp.MustCompile(`[^a-z0-9-]+`).ReplaceAllString(s, "-")
+	s = regexp.MustCompile(`-{2,}`).ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "local"
+	}
+	return s
+}
 
 // AutomationServerConfig handles reading and writing of Bitswan automation server configuration
 type AutomationServerConfig struct {
@@ -17,8 +31,19 @@ type AutomationServerConfig struct {
 // Config represents the combined TOML configuration
 type Config struct {
 	ActiveWorkspace            string                             `toml:"active_workspace"`
+	Name                       string                             `toml:"name,omitempty"`
+	Slug                       string                             `toml:"slug,omitempty"`
 	AutomationOperationsCenter AutomationOperationsCenterSettings `toml:"aoc"`
 	LocalServer                LocalServerSettings                `toml:"local_server"`
+}
+
+// InternalDomain returns the fake internal domain for this automation server.
+// Format: <slug>.bswn.internal (e.g., acme-corp.bswn.internal)
+func (c *Config) InternalDomain() string {
+	if c.Slug == "" {
+		return "local.bswn.internal"
+	}
+	return c.Slug + ".bswn.internal"
 }
 
 // LocalServerSettings represents the local automation server daemon settings
@@ -129,6 +154,17 @@ func (m *AutomationServerConfig) saveTOMLConfig(config *Config) error {
 	}
 
 	return nil
+}
+
+// SetNameAndSlug sets the automation server display name and DNS slug.
+func (m *AutomationServerConfig) SetNameAndSlug(name string) error {
+	config, err := m.LoadConfig()
+	if err != nil {
+		config = &Config{}
+	}
+	config.Name = name
+	config.Slug = Slugify(name)
+	return m.SaveConfig(config)
 }
 
 // UpdateAutomationServer updates only the automation server settings

--- a/internal/config/randomname.go
+++ b/internal/config/randomname.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// Docker-style random name generation: adjective-noun
+var adjectives = []string{
+	"bold", "bright", "calm", "cool", "eager", "fair", "fast", "keen",
+	"kind", "neat", "proud", "quick", "sharp", "smart", "swift", "warm",
+	"brave", "clever", "daring", "gentle", "happy", "jolly", "lively",
+	"merry", "noble", "plucky", "ready", "steady", "witty", "zen",
+}
+
+var nouns = []string{
+	"falcon", "heron", "osprey", "condor", "eagle", "hawk", "raven",
+	"sparrow", "finch", "crane", "stork", "wren", "robin", "swift",
+	"lark", "dove", "owl", "kite", "tern", "ibis", "puffin", "rail",
+	"pipit", "grebe", "shrike", "vireo", "oriole", "cedar", "maple",
+}
+
+// GenerateRandomName produces a Docker-style random name like "bold-falcon".
+func GenerateRandomName() string {
+	adj := adjectives[rand.Intn(len(adjectives))]
+	noun := nouns[rand.Intn(len(nouns))]
+	return fmt.Sprintf("%s-%s", adj, noun)
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -740,6 +740,32 @@ func (c *Client) ListIngressRoutes() (*IngressListRoutesResponse, error) {
 	return &result, nil
 }
 
+// ListVPNIngressRoutes lists all routes in the VPN-internal ingress proxy.
+func (c *Client) ListVPNIngressRoutes() (*IngressListRoutesResponse, error) {
+	req, err := http.NewRequest("GET", "http://unix/ingress/list-routes?target=internal", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var result IngressListRoutesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
 // RemoveIngressRoute removes a route from the ingress proxy
 func (c *Client) RemoveIngressRoute(hostname string) error {
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://unix/ingress/remove-route/%s", hostname), nil)

--- a/internal/daemon/ingress.go
+++ b/internal/daemon/ingress.go
@@ -507,8 +507,13 @@ providers:
 		}
 	}
 
-	// No stage networks — just bitswan_network for backward compatibility
-	traefikDockerCompose, err := dockercompose.CreateWorkspaceTraefikDockerComposeFile(workspaceName, traefikConfigForCompose, domain, nil)
+	// Pass per-workspace stage networks so sub-Traefik can route to containers on each stage network
+	stageNetworks := []string{
+		workspaceName + "-dev",
+		workspaceName + "-staging",
+		workspaceName + "-production",
+	}
+	traefikDockerCompose, err := dockercompose.CreateWorkspaceTraefikDockerComposeFile(workspaceName, traefikConfigForCompose, domain, stageNetworks)
 	if err != nil {
 		return false, fmt.Errorf("failed to create workspace traefik docker-compose file: %w", err)
 	}

--- a/internal/daemon/ingress.go
+++ b/internal/daemon/ingress.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -44,6 +45,11 @@ type IngressAddRouteRequest struct {
 	CertsDir      string `json:"certs_dir,omitempty"`
 	Secret        string `json:"secret,omitempty"`
 	WorkspaceName string `json:"workspace_name,omitempty"`
+	// IngressTarget controls which ingress receives the route when VPN is enabled.
+	// "external" = internet-facing Traefik only
+	// "internal" = VPN Traefik only
+	// "both" or "" = both (default, backward compatible)
+	IngressTarget string `json:"ingress_target,omitempty"`
 }
 
 // IngressAddRouteResponse represents the response from adding a route
@@ -635,9 +641,21 @@ func resolveWorkspaceName(req IngressAddRouteRequest, jwtToken string) string {
 	return ""
 }
 
+// IsVPNEnabled checks whether VPN mode is active.
+func IsVPNEnabled() bool {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(homeDir, ".config", "bitswan", "vpn", "enabled"))
+	return err == nil
+}
+
 // addRouteToIngress adds a route using whichever ingress is running.
 // For Traefik with a workspace name, it sets up two-tier routing
 // (platform traefik → workspace sub-traefik → container).
+// When VPN is enabled, routes are dispatched to external Traefik,
+// VPN Traefik, or both based on req.IngressTarget.
 func addRouteToIngress(req IngressAddRouteRequest, jwtToken string) error {
 	if req.Hostname == "" {
 		return fmt.Errorf("hostname is required")
@@ -648,15 +666,59 @@ func addRouteToIngress(req IngressAddRouteRequest, jwtToken string) error {
 
 	ingressType := DetectIngressType()
 
-	switch ingressType {
-	case IngressCaddy:
-		return addRouteCaddy(req)
-	case IngressTraefik:
-		workspaceName := resolveWorkspaceName(req, jwtToken)
-		return addRouteTraefik(req, workspaceName)
+	if !IsVPNEnabled() {
+		// No VPN — single ingress, ignore IngressTarget
+		switch ingressType {
+		case IngressCaddy:
+			return addRouteCaddy(req)
+		case IngressTraefik:
+			workspaceName := resolveWorkspaceName(req, jwtToken)
+			return addRouteTraefik(req, workspaceName)
+		}
+		return fmt.Errorf("no ingress proxy detected")
 	}
 
-	return fmt.Errorf("no ingress proxy detected")
+	// VPN enabled — dispatch to external, internal, or both
+	target := req.IngressTarget
+	if target == "" {
+		target = "both"
+	}
+
+	var errs []error
+
+	if target == "external" || target == "both" {
+		switch ingressType {
+		case IngressCaddy:
+			if err := addRouteCaddy(req); err != nil {
+				errs = append(errs, fmt.Errorf("external ingress: %w", err))
+			}
+		case IngressTraefik:
+			workspaceName := resolveWorkspaceName(req, jwtToken)
+			if err := addRouteTraefik(req, workspaceName); err != nil {
+				errs = append(errs, fmt.Errorf("external ingress: %w", err))
+			}
+		}
+	}
+
+	if target == "internal" || target == "both" {
+		if err := addRouteVPNTraefik(req); err != nil {
+			errs = append(errs, fmt.Errorf("vpn ingress: %w", err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%v", errs)
+	}
+	return nil
+}
+
+// addRouteVPNTraefik adds a route to the VPN-internal Traefik instance.
+func addRouteVPNTraefik(req IngressAddRouteRequest) error {
+	vpnTraefikURL := os.Getenv("BITSWAN_VPN_TRAEFIK_HOST")
+	if vpnTraefikURL == "" {
+		vpnTraefikURL = "http://traefik-vpn:8080"
+	}
+	return traefikapi.AddRouteWithTraefik(req.Hostname, req.Upstream, vpnTraefikURL)
 }
 
 // addRouteCaddy adds a route to Caddy

--- a/internal/daemon/ingress.go
+++ b/internal/daemon/ingress.go
@@ -678,10 +678,13 @@ func addRouteToIngress(req IngressAddRouteRequest, jwtToken string) error {
 		return fmt.Errorf("no ingress proxy detected")
 	}
 
-	// VPN enabled — dispatch to external, internal, or both
+	// VPN enabled — dispatch to external, internal, or both.
+	// Empty IngressTarget means the caller hasn't been updated for VPN yet,
+	// so default to external-only (safe default — internal routes must be
+	// explicitly requested).
 	target := req.IngressTarget
 	if target == "" {
-		target = "both"
+		target = "external"
 	}
 
 	var errs []error

--- a/internal/daemon/ingress.go
+++ b/internal/daemon/ingress.go
@@ -1110,6 +1110,47 @@ func (s *Server) handleIngressListRoutes(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	target := r.URL.Query().Get("target")
+
+	// If requesting VPN internal routes, query the VPN Traefik directly
+	if target == "internal" && IsVPNEnabled() {
+		vpnURL := os.Getenv("BITSWAN_VPN_TRAEFIK_HOST")
+		if vpnURL == "" {
+			vpnURL = "http://traefik-vpn:8080"
+		}
+		routes, err := traefikapi.ListRoutesWithTraefik(vpnURL)
+		if err != nil {
+			writeJSONError(w, "failed to list VPN routes: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var routeInfos []RouteInfo
+		for _, route := range routes {
+			var hostnames []string
+			for _, match := range route.Match {
+				hostnames = append(hostnames, match.Host...)
+			}
+			var upstreams []string
+			for _, handle := range route.Handle {
+				if handle.Handler == "reverse_proxy" {
+					for _, upstream := range handle.Upstreams {
+						upstreams = append(upstreams, upstream.Dial)
+					}
+				}
+			}
+			if len(hostnames) > 0 && len(upstreams) > 0 {
+				routeInfos = append(routeInfos, RouteInfo{
+					ID:       route.ID,
+					Hostname: hostnames[0],
+					Upstream: upstreams[0],
+					Terminal: route.Terminal,
+				})
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(IngressListRoutesResponse{Routes: routeInfos})
+		return
+	}
+
 	ingressType := DetectIngressType()
 	var routeInfos []RouteInfo
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -158,6 +158,7 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	mux.HandleFunc("/vpn/revoke", s.authMiddleware(s.handleVPNRevoke))
 	mux.HandleFunc("/vpn/users", s.authMiddleware(s.handleVPNListUsers))
 	mux.HandleFunc("/vpn/magic-link", s.authMiddleware(s.handleVPNMagicLink))
+	mux.HandleFunc("/vpn/destroy", s.authMiddleware(s.handleVPNDestroy))
 
 	// MQTT endpoints (authenticated)
 	mux.HandleFunc("/mqtt/reinitialize", s.authMiddleware(s.handleMQTTReinitialize))

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -168,6 +168,14 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	// Docs endpoint (unauthenticated - public access)
 	mux.HandleFunc("/api-docs", s.handleDocs)
 
+	// VPN admin web pages (served on this mux, routed via ingress)
+	// External page: OAuth-protected by the ingress proxy (not by daemon auth)
+	mux.HandleFunc("/vpn-admin", s.handleVPNAdminExternal)
+	mux.HandleFunc("/vpn-admin/", s.handleVPNAdminExternal)
+	// Internal page: only reachable via VPN Traefik
+	mux.HandleFunc("/vpn-admin-internal", s.handleVPNAdminInternal)
+	mux.HandleFunc("/vpn-admin-internal/", s.handleVPNAdminInternal)
+
 	return mux
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -151,6 +151,13 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	mux.HandleFunc("/service", s.authMiddleware(s.handleService))
 	mux.HandleFunc("/service/", s.authMiddleware(s.handleService))
 
+	// VPN endpoints (authenticated)
+	mux.HandleFunc("/vpn/init", s.authMiddleware(s.handleVPNInit))
+	mux.HandleFunc("/vpn/status", s.authMiddleware(s.handleVPNStatus))
+	mux.HandleFunc("/vpn/credentials", s.authMiddleware(s.handleVPNGenerateCredentials))
+	mux.HandleFunc("/vpn/revoke", s.authMiddleware(s.handleVPNRevoke))
+	mux.HandleFunc("/vpn/users", s.authMiddleware(s.handleVPNListUsers))
+
 	// MQTT endpoints (authenticated)
 	mux.HandleFunc("/mqtt/reinitialize", s.authMiddleware(s.handleMQTTReinitialize))
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -157,6 +157,7 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	mux.HandleFunc("/vpn/credentials", s.authMiddleware(s.handleVPNGenerateCredentials))
 	mux.HandleFunc("/vpn/revoke", s.authMiddleware(s.handleVPNRevoke))
 	mux.HandleFunc("/vpn/users", s.authMiddleware(s.handleVPNListUsers))
+	mux.HandleFunc("/vpn/magic-link", s.authMiddleware(s.handleVPNMagicLink))
 
 	// MQTT endpoints (authenticated)
 	mux.HandleFunc("/mqtt/reinitialize", s.authMiddleware(s.handleMQTTReinitialize))

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -159,6 +159,7 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	mux.HandleFunc("/vpn/users", s.authMiddleware(s.handleVPNListUsers))
 	mux.HandleFunc("/vpn/magic-link", s.authMiddleware(s.handleVPNMagicLink))
 	mux.HandleFunc("/vpn/destroy", s.authMiddleware(s.handleVPNDestroy))
+	mux.HandleFunc("/vpn/sessions", s.authMiddleware(s.handleVPNSessions))
 
 	// MQTT endpoints (authenticated)
 	mux.HandleFunc("/mqtt/reinitialize", s.authMiddleware(s.handleMQTTReinitialize))

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -149,18 +149,14 @@ providers:
 	}
 
 	// 7. Register VPN admin routes on both ingresses
-	domain := os.Getenv("BITSWAN_GITOPS_DOMAIN")
-	if domain == "" {
-		domain = "bswn.internal"
-	}
-
-	// Load config for internal domain
 	cfg := config.NewAutomationServerConfig()
 	serverConfig, _ := cfg.LoadConfig()
-	internalDomain := "bswn.internal"
-	if serverConfig != nil {
-		internalDomain = serverConfig.InternalDomain()
+	if serverConfig == nil || serverConfig.Domain == "" {
+		http.Error(w, "No domain configured. Register with AOC first or set domain in automation_server_config.toml.", http.StatusBadRequest)
+		return
 	}
+	domain := serverConfig.Domain
+	internalDomain := serverConfig.InternalDomain()
 
 	// External admin page: vpn-admin.{domain} → daemon:8080
 	externalAdminReq := IngressAddRouteRequest{

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -195,9 +195,9 @@ func (s *Server) handleVPNStatus(w http.ResponseWriter, r *http.Request) {
 
 	if initialized {
 		pub, _ := mgr.ServerPublicKey()
-		users, _ := mgr.ListClients()
+		devices, _ := mgr.ListDevices()
 		result["server_public_key"] = pub
-		result["user_count"] = len(users)
+		result["device_count"] = len(devices)
 	}
 
 	json.NewEncoder(w).Encode(result)
@@ -210,7 +210,8 @@ func (s *Server) handleVPNGenerateCredentials(w http.ResponseWriter, r *http.Req
 	}
 
 	var body struct {
-		UserID string `json:"user_id"`
+		UserID     string `json:"user_id"`
+		DeviceName string `json:"device_name"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
@@ -220,16 +221,20 @@ func (s *Server) handleVPNGenerateCredentials(w http.ResponseWriter, r *http.Req
 		http.Error(w, "user_id is required", http.StatusBadRequest)
 		return
 	}
+	if body.DeviceName == "" {
+		body.DeviceName = "default"
+	}
 
 	mgr := vpnManager()
-	conf, err := mgr.GenerateClient(body.UserID)
+	conf, err := mgr.GenerateClient(body.UserID, body.DeviceName)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate credentials: %v", err), http.StatusInternalServerError)
 		return
 	}
 
+	filename := fmt.Sprintf("%s-%s.conf", body.UserID, body.DeviceName)
 	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.conf", body.UserID))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
 	w.Write(conf)
 }
 
@@ -240,37 +245,37 @@ func (s *Server) handleVPNRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		UserID string `json:"user_id"`
+		DeviceID string `json:"device_id"` // "user/device" format
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
-	if body.UserID == "" {
-		http.Error(w, "user_id is required", http.StatusBadRequest)
+	if body.DeviceID == "" {
+		http.Error(w, "device_id is required (format: user/device)", http.StatusBadRequest)
 		return
 	}
 
 	mgr := vpnManager()
-	if err := mgr.RevokeClient(body.UserID); err != nil {
+	if err := mgr.RevokeDevice(body.DeviceID); err != nil {
 		http.Error(w, fmt.Sprintf("failed to revoke: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	json.NewEncoder(w).Encode(map[string]string{"status": "revoked", "user_id": body.UserID})
+	json.NewEncoder(w).Encode(map[string]string{"status": "revoked", "device_id": body.DeviceID})
 }
 
 func (s *Server) handleVPNListUsers(w http.ResponseWriter, r *http.Request) {
 	mgr := vpnManager()
-	users, err := mgr.ListClients()
+	devices, err := mgr.ListDevices()
 	if err != nil {
-		http.Error(w, fmt.Sprintf("failed to list users: %v", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("failed to list devices: %v", err), http.StatusInternalServerError)
 		return
 	}
-	if users == nil {
-		users = []vpn.VPNUser{}
+	if devices == nil {
+		devices = []vpn.VPNDevice{}
 	}
-	json.NewEncoder(w).Encode(users)
+	json.NewEncoder(w).Encode(devices)
 }
 
 func (s *Server) handleVPNMagicLink(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -178,9 +178,15 @@ providers:
 		fmt.Printf("Warning: failed to register internal VPN admin route: %v\n", err)
 	}
 
+	// 8. Start session monitor (iptables LOG → wg show enrichment)
+	monitor := vpn.NewSessionMonitor(mgr)
+	if err := monitor.Start(); err != nil {
+		fmt.Printf("Warning: failed to start session monitor: %v\n", err)
+	}
+
 	json.NewEncoder(w).Encode(map[string]string{
 		"status":  "initialized",
-		"message": "WireGuard VPN initialized with VPN Traefik and CoreDNS.",
+		"message": "WireGuard VPN initialized with VPN Traefik, CoreDNS, and session monitoring.",
 	})
 }
 
@@ -276,6 +282,38 @@ func (s *Server) handleVPNListUsers(w http.ResponseWriter, r *http.Request) {
 		devices = []vpn.VPNDevice{}
 	}
 	json.NewEncoder(w).Encode(devices)
+}
+
+func (s *Server) handleVPNSessions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	mgr := vpnManager()
+	monitor := vpn.NewSessionMonitor(mgr)
+
+	// Check for ?active=true query param
+	if r.URL.Query().Get("active") == "true" {
+		active := monitor.GetActiveSessions()
+		if active == nil {
+			active = []vpn.SessionEvent{}
+		}
+		json.NewEncoder(w).Encode(active)
+		return
+	}
+
+	// Return recent session log
+	limit := 100
+	events, err := monitor.GetSessionLog(limit)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to read session log: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if events == nil {
+		events = []vpn.SessionEvent{}
+	}
+	json.NewEncoder(w).Encode(events)
 }
 
 func (s *Server) handleVPNMagicLink(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -75,6 +75,16 @@ func (s *Server) handleVPNInit(w http.ResponseWriter, r *http.Request) {
 	vpnPath := filepath.Join(homeDir, ".config", "bitswan", "vpn")
 	vpnTraefikPath := filepath.Join(homeDir, ".config", "bitswan", "traefik-vpn")
 
+	// Docker compose volume mounts need host paths, not daemon container paths.
+	// HOST_HOME maps the daemon's /root to the actual host home dir.
+	hostHome := os.Getenv("HOST_HOME")
+	hostVpnPath := vpnPath
+	hostVpnTraefikPath := vpnTraefikPath
+	if hostHome != "" {
+		hostVpnPath = filepath.Join(hostHome, ".config", "bitswan", "vpn")
+		hostVpnTraefikPath = filepath.Join(hostHome, ".config", "bitswan", "traefik-vpn")
+	}
+
 	// 1. Initialize WireGuard server config (idempotent — skips if already done)
 	mgr := vpnManager()
 	if !mgr.IsInitialized() {
@@ -88,7 +98,7 @@ func (s *Server) handleVPNInit(w http.ResponseWriter, r *http.Request) {
 	docker.EnsureDockerNetwork("bitswan_vpn_network", true)
 
 	// 3. Start WireGuard container
-	wgCompose, err := dockercompose.CreateWireGuardDockerComposeFile(vpnPath, 51820)
+	wgCompose, err := dockercompose.CreateWireGuardDockerComposeFile(hostVpnPath, 51820)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate WireGuard compose: %v", err), http.StatusInternalServerError)
 		return
@@ -112,7 +122,7 @@ providers:
 	os.WriteFile(filepath.Join(vpnTraefikPath, "traefik.yml"), []byte(traefikYml), 0644)
 
 	// 5. Start VPN Traefik container
-	vpnTraefikCompose, err := dockercompose.CreateVPNTraefikDockerComposeFile(vpnTraefikPath)
+	vpnTraefikCompose, err := dockercompose.CreateVPNTraefikDockerComposeFile(hostVpnTraefikPath)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate VPN Traefik compose: %v", err), http.StatusInternalServerError)
 		return
@@ -122,8 +132,12 @@ providers:
 		return
 	}
 
-	// 6. Start CoreDNS
-	corednsCompose, err := dockercompose.CreateCoreDNSDockerComposeFile(vpnPath, "")
+	// 6. Write Corefile (locally) and start CoreDNS
+	if err := dockercompose.WriteCorefile(vpnPath, ""); err != nil {
+		http.Error(w, fmt.Sprintf("failed to write Corefile: %v", err), http.StatusInternalServerError)
+		return
+	}
+	corednsCompose, err := dockercompose.CreateCoreDNSDockerComposeFile(hostVpnPath)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to generate CoreDNS compose: %v", err), http.StatusInternalServerError)
 		return

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/bitswan-space/bitswan-workspaces/internal/config"
 	"github.com/bitswan-space/bitswan-workspaces/internal/docker"
 	"github.com/bitswan-space/bitswan-workspaces/internal/dockercompose"
 	"github.com/bitswan-space/bitswan-workspaces/internal/vpn"
@@ -145,6 +146,40 @@ providers:
 	if err := dockerComposeUp("coredns-vpn", corednsCompose, vpnPath); err != nil {
 		http.Error(w, fmt.Sprintf("failed to start CoreDNS: %v", err), http.StatusInternalServerError)
 		return
+	}
+
+	// 7. Register VPN admin routes on both ingresses
+	domain := os.Getenv("BITSWAN_GITOPS_DOMAIN")
+	if domain == "" {
+		domain = "bswn.internal"
+	}
+
+	// Load config for internal domain
+	cfg := config.NewAutomationServerConfig()
+	serverConfig, _ := cfg.LoadConfig()
+	internalDomain := "bswn.internal"
+	if serverConfig != nil {
+		internalDomain = serverConfig.InternalDomain()
+	}
+
+	// External admin page: vpn-admin.{domain} → daemon:8080
+	externalAdminReq := IngressAddRouteRequest{
+		Hostname:      "vpn-admin." + domain,
+		Upstream:      "bitswan-automation-server-daemon:8080",
+		IngressTarget: "external",
+	}
+	if err := addRouteToIngress(externalAdminReq, ""); err != nil {
+		fmt.Printf("Warning: failed to register external VPN admin route: %v\n", err)
+	}
+
+	// Internal admin page: vpn-admin.{internalDomain} → daemon:8080
+	internalAdminReq := IngressAddRouteRequest{
+		Hostname:      "vpn-admin." + internalDomain,
+		Upstream:      "bitswan-automation-server-daemon:8080",
+		IngressTarget: "internal",
+	}
+	if err := addRouteToIngress(internalAdminReq, ""); err != nil {
+		fmt.Printf("Warning: failed to register internal VPN admin route: %v\n", err)
 	}
 
 	json.NewEncoder(w).Encode(map[string]string{

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -1,0 +1,135 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/vpn"
+)
+
+func vpnManager() *vpn.Manager {
+	homeDir, _ := os.UserHomeDir()
+	return vpn.NewManager(filepath.Join(homeDir, ".config", "bitswan"))
+}
+
+func (s *Server) handleVPNInit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		Endpoint string `json:"endpoint"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.Endpoint == "" {
+		http.Error(w, "endpoint is required (e.g., vpn.example.com)", http.StatusBadRequest)
+		return
+	}
+
+	mgr := vpnManager()
+	if err := mgr.Init(body.Endpoint); err != nil {
+		http.Error(w, fmt.Sprintf("failed to initialize VPN: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "initialized",
+		"message": "WireGuard VPN initialized. Start the container with 'bitswan vpn start'.",
+	})
+}
+
+func (s *Server) handleVPNStatus(w http.ResponseWriter, r *http.Request) {
+	mgr := vpnManager()
+	initialized := mgr.IsInitialized()
+
+	result := map[string]interface{}{
+		"enabled":     IsVPNEnabled(),
+		"initialized": initialized,
+	}
+
+	if initialized {
+		pub, _ := mgr.ServerPublicKey()
+		users, _ := mgr.ListClients()
+		result["server_public_key"] = pub
+		result["user_count"] = len(users)
+	}
+
+	json.NewEncoder(w).Encode(result)
+}
+
+func (s *Server) handleVPNGenerateCredentials(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.UserID == "" {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+
+	mgr := vpnManager()
+	conf, err := mgr.GenerateClient(body.UserID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to generate credentials: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.conf", body.UserID))
+	w.Write(conf)
+}
+
+func (s *Server) handleVPNRevoke(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.UserID == "" {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+
+	mgr := vpnManager()
+	if err := mgr.RevokeClient(body.UserID); err != nil {
+		http.Error(w, fmt.Sprintf("failed to revoke: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{"status": "revoked", "user_id": body.UserID})
+}
+
+func (s *Server) handleVPNListUsers(w http.ResponseWriter, r *http.Request) {
+	mgr := vpnManager()
+	users, err := mgr.ListClients()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to list users: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if users == nil {
+		users = []vpn.VPNUser{}
+	}
+	json.NewEncoder(w).Encode(users)
+}

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -5,10 +5,26 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
+	"github.com/bitswan-space/bitswan-workspaces/internal/docker"
+	"github.com/bitswan-space/bitswan-workspaces/internal/dockercompose"
 	"github.com/bitswan-space/bitswan-workspaces/internal/vpn"
 )
+
+// dockerComposeUp runs docker compose up -d with the given compose content.
+func dockerComposeUp(projectName, composeContent, workDir string) error {
+	cmd := exec.Command("docker", "compose", "-p", projectName, "-f", "/dev/stdin", "up", "-d")
+	cmd.Stdin = strings.NewReader(composeContent)
+	cmd.Dir = workDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", err, string(out))
+	}
+	return nil
+}
 
 func vpnManager() *vpn.Manager {
 	homeDir, _ := os.UserHomeDir()
@@ -22,7 +38,8 @@ func (s *Server) handleVPNInit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Endpoint string `json:"endpoint"`
+		Endpoint       string `json:"endpoint"`
+		InternalDomain string `json:"internal_domain"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
@@ -33,15 +50,69 @@ func (s *Server) handleVPNInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	homeDir, _ := os.UserHomeDir()
+	vpnPath := filepath.Join(homeDir, ".config", "bitswan", "vpn")
+	vpnTraefikPath := filepath.Join(homeDir, ".config", "bitswan", "traefik-vpn")
+
+	// 1. Initialize WireGuard server config
 	mgr := vpnManager()
 	if err := mgr.Init(body.Endpoint); err != nil {
 		http.Error(w, fmt.Sprintf("failed to initialize VPN: %v", err), http.StatusInternalServerError)
 		return
 	}
 
+	// 2. Create bitswan_vpn_network
+	docker.EnsureDockerNetwork("bitswan_vpn_network", true)
+
+	// 3. Start WireGuard container
+	wgCompose, err := dockercompose.CreateWireGuardDockerComposeFile(vpnPath, 51820)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to generate WireGuard compose: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if err := dockerComposeUp("wireguard", wgCompose, vpnPath); err != nil {
+		http.Error(w, fmt.Sprintf("failed to start WireGuard: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// 4. Write VPN Traefik config
+	os.MkdirAll(vpnTraefikPath, 0755)
+	traefikYml := `entryPoints:
+  web:
+    address: ":80"
+api:
+  insecure: true
+providers:
+  rest:
+    insecure: true
+`
+	os.WriteFile(filepath.Join(vpnTraefikPath, "traefik.yml"), []byte(traefikYml), 0644)
+
+	// 5. Start VPN Traefik container
+	vpnTraefikCompose, err := dockercompose.CreateVPNTraefikDockerComposeFile(vpnTraefikPath)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to generate VPN Traefik compose: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if err := dockerComposeUp("traefik-vpn", vpnTraefikCompose, vpnTraefikPath); err != nil {
+		http.Error(w, fmt.Sprintf("failed to start VPN Traefik: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// 6. Start CoreDNS
+	corednsCompose, err := dockercompose.CreateCoreDNSDockerComposeFile(vpnPath, "")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to generate CoreDNS compose: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if err := dockerComposeUp("coredns-vpn", corednsCompose, vpnPath); err != nil {
+		http.Error(w, fmt.Sprintf("failed to start CoreDNS: %v", err), http.StatusInternalServerError)
+		return
+	}
+
 	json.NewEncoder(w).Encode(map[string]string{
 		"status":  "initialized",
-		"message": "WireGuard VPN initialized. Start the container with 'bitswan vpn start'.",
+		"message": "WireGuard VPN initialized with VPN Traefik and CoreDNS.",
 	})
 }
 

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -133,3 +133,37 @@ func (s *Server) handleVPNListUsers(w http.ResponseWriter, r *http.Request) {
 	}
 	json.NewEncoder(w).Encode(users)
 }
+
+func (s *Server) handleVPNMagicLink(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		CreatedBy string `json:"created_by"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.CreatedBy == "" {
+		body.CreatedBy = "admin"
+	}
+
+	store := magicLinkStore()
+	token, err := store.Create(body.CreatedBy)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to create magic link: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	domain := os.Getenv("BITSWAN_GITOPS_DOMAIN")
+	claimURL := fmt.Sprintf("https://vpn-admin.%s/vpn-admin/claim/%s", domain, token)
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"token":     token,
+		"claim_url": claimURL,
+		"expires":   "1 hour",
+	})
+}

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -15,9 +15,31 @@ import (
 )
 
 // dockerComposeUp runs docker compose up -d with the given compose content.
+// dockerComposeUp writes the compose content to a file and runs docker compose up -d.
 func dockerComposeUp(projectName, composeContent, workDir string) error {
-	cmd := exec.Command("docker", "compose", "-p", projectName, "-f", "/dev/stdin", "up", "-d")
-	cmd.Stdin = strings.NewReader(composeContent)
+	composePath := filepath.Join(workDir, "docker-compose.yaml")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		return fmt.Errorf("failed to create dir %s: %w", workDir, err)
+	}
+	if err := os.WriteFile(composePath, []byte(composeContent), 0644); err != nil {
+		return fmt.Errorf("failed to write compose file: %w", err)
+	}
+	cmd := exec.Command("docker", "compose", "-p", projectName, "-f", composePath, "up", "-d")
+	cmd.Dir = workDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", err, string(out))
+	}
+	return nil
+}
+
+// dockerComposeDown stops and removes containers for a compose project.
+func dockerComposeDown(projectName, workDir string) error {
+	composePath := filepath.Join(workDir, "docker-compose.yaml")
+	if _, err := os.Stat(composePath); os.IsNotExist(err) {
+		return nil // nothing to tear down
+	}
+	cmd := exec.Command("docker", "compose", "-p", projectName, "-f", composePath, "down", "--remove-orphans")
 	cmd.Dir = workDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -54,11 +76,13 @@ func (s *Server) handleVPNInit(w http.ResponseWriter, r *http.Request) {
 	vpnPath := filepath.Join(homeDir, ".config", "bitswan", "vpn")
 	vpnTraefikPath := filepath.Join(homeDir, ".config", "bitswan", "traefik-vpn")
 
-	// 1. Initialize WireGuard server config
+	// 1. Initialize WireGuard server config (idempotent — skips if already done)
 	mgr := vpnManager()
-	if err := mgr.Init(body.Endpoint); err != nil {
-		http.Error(w, fmt.Sprintf("failed to initialize VPN: %v", err), http.StatusInternalServerError)
-		return
+	if !mgr.IsInitialized() {
+		if err := mgr.Init(body.Endpoint); err != nil {
+			http.Error(w, fmt.Sprintf("failed to initialize VPN: %v", err), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// 2. Create bitswan_vpn_network
@@ -236,5 +260,47 @@ func (s *Server) handleVPNMagicLink(w http.ResponseWriter, r *http.Request) {
 		"token":     token,
 		"claim_url": claimURL,
 		"expires":   "1 hour",
+	})
+}
+
+func (s *Server) handleVPNDestroy(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	homeDir, _ := os.UserHomeDir()
+	vpnPath := filepath.Join(homeDir, ".config", "bitswan", "vpn")
+	vpnTraefikPath := filepath.Join(homeDir, ".config", "bitswan", "traefik-vpn")
+
+	var errors []string
+
+	// Stop containers
+	if err := dockerComposeDown("coredns-vpn", vpnPath); err != nil {
+		errors = append(errors, fmt.Sprintf("coredns: %v", err))
+	}
+	if err := dockerComposeDown("traefik-vpn", vpnTraefikPath); err != nil {
+		errors = append(errors, fmt.Sprintf("traefik-vpn: %v", err))
+	}
+	if err := dockerComposeDown("wireguard", vpnPath); err != nil {
+		errors = append(errors, fmt.Sprintf("wireguard: %v", err))
+	}
+
+	// Remove config
+	os.RemoveAll(vpnPath)
+	os.RemoveAll(vpnTraefikPath)
+
+	if len(errors) > 0 {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":   "partial",
+			"message":  "VPN destroyed with some errors",
+			"errors":   errors,
+		})
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "destroyed",
+		"message": "VPN infrastructure removed. Containers stopped, config deleted.",
 	})
 }

--- a/internal/daemon/vpn.go
+++ b/internal/daemon/vpn.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/docker"
 	"github.com/bitswan-space/bitswan-workspaces/internal/dockercompose"

--- a/internal/daemon/vpn_admin.go
+++ b/internal/daemon/vpn_admin.go
@@ -32,7 +32,7 @@ func (s *Server) handleVPNAdminExternal(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		mgr := vpnManager()
-		users, _ := mgr.ListClients()
+		users, _ := mgr.ListDevices()
 		if len(users) > 0 {
 			http.Error(w, "bootstrap already completed — use a magic link instead", http.StatusForbidden)
 			return
@@ -42,7 +42,7 @@ func (s *Server) handleVPNAdminExternal(w http.ResponseWriter, r *http.Request) 
 		if email == "" {
 			email = "admin"
 		}
-		conf, err := mgr.GenerateClient(email)
+		conf, err := mgr.GenerateClient(email, "web")
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to generate credentials: %v", err), http.StatusInternalServerError)
 			return
@@ -81,7 +81,7 @@ func (s *Server) handleVPNAdminExternal(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		mgr := vpnManager()
-		conf, err := mgr.GenerateClient(email)
+		conf, err := mgr.GenerateClient(email, "web")
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to generate credentials: %v", err), http.StatusInternalServerError)
 			return
@@ -145,9 +145,9 @@ func (s *Server) handleVPNAdminInternal(w http.ResponseWriter, r *http.Request) 
 
 	case r.URL.Path == "/vpn-admin-internal/api/users":
 		mgr := vpnManager()
-		users, _ := mgr.ListClients()
+		users, _ := mgr.ListDevices()
 		if users == nil {
-			users = []vpn.VPNUser{}
+			users = []vpn.VPNDevice{}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(users)
@@ -160,7 +160,7 @@ func (s *Server) handleVPNAdminInternal(w http.ResponseWriter, r *http.Request) 
 		}
 		userID := strings.TrimPrefix(r.URL.Path, "/vpn-admin-internal/api/revoke/")
 		mgr := vpnManager()
-		if err := mgr.RevokeClient(userID); err != nil {
+		if err := mgr.RevokeDevice(userID); err != nil {
 			http.Error(w, fmt.Sprintf("failed to revoke: %v", err), http.StatusInternalServerError)
 			return
 		}

--- a/internal/daemon/vpn_admin.go
+++ b/internal/daemon/vpn_admin.go
@@ -1,0 +1,314 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/vpn"
+)
+
+func magicLinkStore() *vpn.MagicLinkStore {
+	homeDir, _ := os.UserHomeDir()
+	return vpn.NewMagicLinkStore(filepath.Join(homeDir, ".config", "bitswan"))
+}
+
+// handleVPNAdminExternal serves the external VPN admin page.
+// This page is exposed on the internet (via external Traefik) and is OAuth-protected.
+// It allows: first-admin bootstrap download, magic link claim + credential download.
+func (s *Server) handleVPNAdminExternal(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/vpn-admin" || r.URL.Path == "/vpn-admin/":
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, vpnAdminExternalHTML())
+
+	case r.URL.Path == "/vpn-admin/bootstrap":
+		// First-admin bootstrap: generate credentials if no users exist
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		mgr := vpnManager()
+		users, _ := mgr.ListClients()
+		if len(users) > 0 {
+			http.Error(w, "bootstrap already completed — use a magic link instead", http.StatusForbidden)
+			return
+		}
+		// Use email from OAuth header (set by oauth2-proxy)
+		email := r.Header.Get("X-Forwarded-Email")
+		if email == "" {
+			email = "admin"
+		}
+		conf, err := mgr.GenerateClient(email)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to generate credentials: %v", err), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", "attachment; filename=wireguard.conf")
+		w.Write(conf)
+
+	case strings.HasPrefix(r.URL.Path, "/vpn-admin/claim/"):
+		// Magic link claim: validate token, generate credentials
+		token := strings.TrimPrefix(r.URL.Path, "/vpn-admin/claim/")
+		if token == "" {
+			http.Error(w, "missing token", http.StatusBadRequest)
+			return
+		}
+		store := magicLinkStore()
+		if err := store.Validate(token); err != nil {
+			http.Error(w, fmt.Sprintf("invalid token: %v", err), http.StatusForbidden)
+			return
+		}
+
+		if r.Method == http.MethodGet {
+			// Show confirmation page
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, vpnAdminClaimHTML(token))
+			return
+		}
+
+		// POST: actually claim and generate credentials
+		email := r.Header.Get("X-Forwarded-Email")
+		if email == "" {
+			email = "user-" + token[:8]
+		}
+		if err := store.Claim(token, email); err != nil {
+			http.Error(w, fmt.Sprintf("failed to claim token: %v", err), http.StatusForbidden)
+			return
+		}
+		mgr := vpnManager()
+		conf, err := mgr.GenerateClient(email)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to generate credentials: %v", err), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", "attachment; filename=wireguard.conf")
+		w.Write(conf)
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// handleVPNAdminInternal serves the internal VPN admin page (behind VPN).
+// Allows: generating magic links, listing users, revoking users.
+func (s *Server) handleVPNAdminInternal(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/vpn-admin-internal" || r.URL.Path == "/vpn-admin-internal/":
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, vpnAdminInternalHTML())
+			return
+		}
+
+	case r.URL.Path == "/vpn-admin-internal/api/magic-link":
+		if r.Method == http.MethodPost {
+			var body struct {
+				CreatedBy string `json:"created_by"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.CreatedBy == "" {
+				body.CreatedBy = "admin"
+			}
+			store := magicLinkStore()
+			token, err := store.Create(body.CreatedBy)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("failed to create magic link: %v", err), http.StatusInternalServerError)
+				return
+			}
+			// Build the claim URL using the external admin hostname
+			domain := os.Getenv("BITSWAN_GITOPS_DOMAIN")
+			claimURL := fmt.Sprintf("https://vpn-admin.%s/vpn-admin/claim/%s", domain, token)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"token":     token,
+				"claim_url": claimURL,
+				"expires":   "1 hour",
+			})
+			return
+		}
+		if r.Method == http.MethodGet {
+			store := magicLinkStore()
+			links, _ := store.List()
+			if links == nil {
+				links = []vpn.MagicLink{}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(links)
+			return
+		}
+
+	case r.URL.Path == "/vpn-admin-internal/api/users":
+		mgr := vpnManager()
+		users, _ := mgr.ListClients()
+		if users == nil {
+			users = []vpn.VPNUser{}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(users)
+		return
+
+	case strings.HasPrefix(r.URL.Path, "/vpn-admin-internal/api/revoke/"):
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		userID := strings.TrimPrefix(r.URL.Path, "/vpn-admin-internal/api/revoke/")
+		mgr := vpnManager()
+		if err := mgr.RevokeClient(userID); err != nil {
+			http.Error(w, fmt.Sprintf("failed to revoke: %v", err), http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"status": "revoked"})
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+// --- HTML templates ---
+
+func vpnAdminExternalHTML() string {
+	return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>BitSwan VPN</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 600px; margin: 60px auto; padding: 0 20px; color: #333; }
+h1 { color: #1a73e8; }
+.card { background: #f8f9fa; border-radius: 8px; padding: 24px; margin: 20px 0; }
+button { background: #1a73e8; color: white; border: none; padding: 12px 24px; border-radius: 6px; cursor: pointer; font-size: 16px; }
+button:hover { background: #1557b0; }
+.note { color: #666; font-size: 14px; }
+</style></head><body>
+<h1>BitSwan VPN Access</h1>
+<div class="card" id="bootstrap-section">
+<h2>First-Time Setup</h2>
+<p>If you are the first administrator, click below to download your VPN configuration.</p>
+<button onclick="bootstrap()">Download VPN Config</button>
+<p class="note">This option is only available when no VPN users exist yet.</p>
+</div>
+<div class="card">
+<h2>Have a Magic Link?</h2>
+<p>If someone shared a magic link with you, paste the token below.</p>
+<input type="text" id="token-input" placeholder="Paste your token here" style="width:100%;padding:10px;margin:10px 0;border:1px solid #ddd;border-radius:4px;">
+<button onclick="claimToken()">Get VPN Config</button>
+</div>
+<script>
+function bootstrap() {
+  fetch('/vpn-admin/bootstrap', {method:'POST'})
+    .then(r => { if (!r.ok) return r.text().then(t => { throw new Error(t) }); return r.blob(); })
+    .then(b => { const a = document.createElement('a'); a.href = URL.createObjectURL(b); a.download = 'wireguard.conf'; a.click(); })
+    .catch(e => alert(e.message));
+}
+function claimToken() {
+  const token = document.getElementById('token-input').value.trim();
+  if (!token) { alert('Please enter a token'); return; }
+  fetch('/vpn-admin/claim/' + token, {method:'POST'})
+    .then(r => { if (!r.ok) return r.text().then(t => { throw new Error(t) }); return r.blob(); })
+    .then(b => { const a = document.createElement('a'); a.href = URL.createObjectURL(b); a.download = 'wireguard.conf'; a.click(); })
+    .catch(e => alert(e.message));
+}
+</script></body></html>`
+}
+
+func vpnAdminClaimHTML(token string) string {
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Claim VPN Access</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 600px; margin: 60px auto; padding: 0 20px; }
+h1 { color: #1a73e8; }
+.card { background: #f8f9fa; border-radius: 8px; padding: 24px; margin: 20px 0; }
+button { background: #1a73e8; color: white; border: none; padding: 12px 24px; border-radius: 6px; cursor: pointer; font-size: 16px; }
+</style></head><body>
+<h1>Claim VPN Access</h1>
+<div class="card">
+<p>Click below to download your WireGuard VPN configuration.</p>
+<form method="POST" action="/vpn-admin/claim/%s">
+<button type="submit">Download VPN Config</button>
+</form>
+</div></body></html>`, token)
+}
+
+func vpnAdminInternalHTML() string {
+	return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>VPN Admin</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; color: #333; }
+h1 { color: #1a73e8; }
+.card { background: #f8f9fa; border-radius: 8px; padding: 24px; margin: 20px 0; }
+button { background: #1a73e8; color: white; border: none; padding: 10px 20px; border-radius: 6px; cursor: pointer; }
+button:hover { background: #1557b0; }
+button.danger { background: #dc3545; }
+button.danger:hover { background: #c82333; }
+table { width: 100%; border-collapse: collapse; margin: 12px 0; }
+th, td { text-align: left; padding: 8px 12px; border-bottom: 1px solid #dee2e6; }
+th { background: #e9ecef; }
+.link-box { background: #fff; border: 1px solid #1a73e8; border-radius: 4px; padding: 12px; margin: 12px 0; word-break: break-all; font-family: monospace; }
+#status { margin: 10px 0; color: #28a745; }
+</style></head><body>
+<h1>VPN Administration</h1>
+
+<div class="card">
+<h2>Generate Magic Link</h2>
+<p>Create a one-time link (valid 1 hour) for a new user to download VPN credentials.</p>
+<button onclick="generateLink()">Generate Magic Link</button>
+<div id="link-result"></div>
+</div>
+
+<div class="card">
+<h2>VPN Users</h2>
+<div id="users-table">Loading...</div>
+</div>
+
+<div class="card">
+<h2>Active Magic Links</h2>
+<div id="links-table">Loading...</div>
+</div>
+
+<script>
+function generateLink() {
+  fetch('/vpn-admin-internal/api/magic-link', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({created_by:'admin'})})
+    .then(r => r.json())
+    .then(d => {
+      document.getElementById('link-result').innerHTML =
+        '<div class="link-box">' + d.claim_url + '</div>' +
+        '<button onclick="navigator.clipboard.writeText(\'' + d.claim_url + '\').then(()=>alert(\'Copied!\'))">Copy to Clipboard</button>' +
+        '<p style="color:#666">Expires in ' + d.expires + '</p>';
+      loadLinks();
+    });
+}
+function loadUsers() {
+  fetch('/vpn-admin-internal/api/users').then(r=>r.json()).then(users => {
+    if (!users.length) { document.getElementById('users-table').innerHTML = '<p>No users yet.</p>'; return; }
+    let html = '<table><tr><th>User</th><th>IP</th><th>Public Key</th><th></th></tr>';
+    users.forEach(u => {
+      html += '<tr><td>'+u.id+'</td><td>'+u.ip+'</td><td style="font-family:monospace;font-size:12px">'+u.public_key+'</td>';
+      html += '<td><button class="danger" onclick="revokeUser(\''+u.id+'\')">Revoke</button></td></tr>';
+    });
+    html += '</table>';
+    document.getElementById('users-table').innerHTML = html;
+  });
+}
+function loadLinks() {
+  fetch('/vpn-admin-internal/api/magic-link').then(r=>r.json()).then(links => {
+    if (!links.length) { document.getElementById('links-table').innerHTML = '<p>No active links.</p>'; return; }
+    let html = '<table><tr><th>Created By</th><th>Expires</th><th>Token (first 8)</th></tr>';
+    links.forEach(l => {
+      html += '<tr><td>'+l.created_by+'</td><td>'+new Date(l.expires_at).toLocaleString()+'</td><td style="font-family:monospace">'+l.token.substring(0,8)+'...</td></tr>';
+    });
+    html += '</table>';
+    document.getElementById('links-table').innerHTML = html;
+  });
+}
+function revokeUser(id) {
+  if (!confirm('Revoke VPN access for ' + id + '?')) return;
+  fetch('/vpn-admin-internal/api/revoke/' + id, {method:'POST'}).then(() => loadUsers());
+}
+loadUsers();
+loadLinks();
+</script></body></html>`
+}

--- a/internal/daemon/workspace_init.go
+++ b/internal/daemon/workspace_init.go
@@ -11,6 +11,9 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"io"
+	"net/http"
+
 	"github.com/bitswan-space/bitswan-workspaces/internal/aoc"
 	"github.com/bitswan-space/bitswan-workspaces/internal/caddyapi"
 	"github.com/bitswan-space/bitswan-workspaces/internal/config"
@@ -22,6 +25,7 @@ import (
 	"github.com/bitswan-space/bitswan-workspaces/internal/ssh"
 	"github.com/bitswan-space/bitswan-workspaces/internal/traefikapi"
 	"github.com/bitswan-space/bitswan-workspaces/internal/util"
+	"github.com/bitswan-space/bitswan-workspaces/internal/vpn"
 )
 
 // runWorkspaceInit runs the workspace init logic with stdout already redirected.
@@ -894,7 +898,113 @@ func saveMetadata(gitopsConfig, workspaceName, token, domain string, noIde bool,
 		return fmt.Errorf("failed to save metadata: %w", err)
 	}
 
+	// Initialize VPN automatically — editor and internal services should
+	// only be accessible through the VPN by default.
+	if !IsVPNEnabled() {
+		fmt.Fprintln(writer, "Initializing VPN...")
+
+		// Auto-detect public IP for VPN endpoint
+		vpnEndpoint := detectPublicIPForVPN()
+		if vpnEndpoint == "" {
+			fmt.Fprintln(writer, "Warning: Could not detect public IP for VPN. Run 'bitswan vpn init --endpoint <ip>' manually.")
+		} else {
+			// Ensure server name exists
+			cfg := config.NewAutomationServerConfig()
+			serverConfig, _ := cfg.LoadConfig()
+			if serverConfig != nil && serverConfig.Slug == "" {
+				cfg.SetNameAndSlug(config.GenerateRandomName())
+			}
+			if serverConfig != nil && serverConfig.Domain == "" {
+				cfg.SetDomain(domain)
+			}
+
+			homeDir := os.Getenv("HOME")
+			vpnPath := filepath.Join(homeDir, ".config", "bitswan", "vpn")
+			vpnTraefikPath := filepath.Join(homeDir, ".config", "bitswan", "traefik-vpn")
+			hostHome := os.Getenv("HOST_HOME")
+			hostVpnPath := vpnPath
+			hostVpnTraefikPath := vpnTraefikPath
+			if hostHome != "" {
+				hostVpnPath = filepath.Join(hostHome, ".config", "bitswan", "vpn")
+				hostVpnTraefikPath = filepath.Join(hostHome, ".config", "bitswan", "traefik-vpn")
+			}
+
+			mgr := vpn.NewManager(filepath.Join(homeDir, ".config", "bitswan"))
+			if !mgr.IsInitialized() {
+				if err := mgr.Init(vpnEndpoint); err != nil {
+					fmt.Fprintf(writer, "Warning: VPN init failed: %v\n", err)
+				}
+			}
+
+			// Create VPN network
+			docker.EnsureDockerNetwork("bitswan_vpn_network", *verbose)
+
+			// Start WireGuard
+			wgCompose, _ := dockercompose.CreateWireGuardDockerComposeFile(hostVpnPath, 51820)
+			if wgCompose != "" {
+				dockerComposeUpQuiet("wireguard", wgCompose, vpnPath)
+			}
+
+			// Start VPN Traefik
+			os.MkdirAll(vpnTraefikPath, 0755)
+			traefikYml := "entryPoints:\n  web:\n    address: \":80\"\napi:\n  insecure: true\nproviders:\n  rest:\n    insecure: true\n"
+			os.WriteFile(filepath.Join(vpnTraefikPath, "traefik.yml"), []byte(traefikYml), 0644)
+			vpnTraefikCompose, _ := dockercompose.CreateVPNTraefikDockerComposeFile(hostVpnTraefikPath)
+			if vpnTraefikCompose != "" {
+				dockerComposeUpQuiet("traefik-vpn", vpnTraefikCompose, vpnTraefikPath)
+			}
+
+			// Start CoreDNS
+			dockercompose.WriteCorefile(vpnPath, "")
+			corednsCompose, _ := dockercompose.CreateCoreDNSDockerComposeFile(hostVpnPath)
+			if corednsCompose != "" {
+				dockerComposeUpQuiet("coredns-vpn", corednsCompose, vpnPath)
+			}
+
+			// Register VPN admin routes
+			serverConfig, _ = cfg.LoadConfig()
+			if serverConfig != nil {
+				internalDomain := serverConfig.InternalDomain()
+				addRouteToIngress(IngressAddRouteRequest{
+					Hostname:      "vpn-admin." + domain,
+					Upstream:      "bitswan-automation-server-daemon:8080",
+					IngressTarget: "external",
+				}, "")
+				addRouteToIngress(IngressAddRouteRequest{
+					Hostname:      "vpn-admin." + internalDomain,
+					Upstream:      "bitswan-automation-server-daemon:8080",
+					IngressTarget: "internal",
+				}, "")
+			}
+
+			fmt.Fprintf(writer, "VPN initialized (endpoint: %s)\n", vpnEndpoint)
+			fmt.Fprintln(writer, "Run 'bitswan vpn bootstrap' to download your VPN config.")
+		}
+	}
+
 	return nil
+}
+
+func detectPublicIPForVPN() string {
+	resp, err := http.Get("https://api.ipify.org")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(body))
+}
+
+func dockerComposeUpQuiet(projectName, composeContent, workDir string) {
+	composePath := filepath.Join(workDir, "docker-compose.yaml")
+	os.MkdirAll(workDir, 0755)
+	os.WriteFile(composePath, []byte(composeContent), 0644)
+	cmd := exec.Command("docker", "compose", "-p", projectName, "-f", composePath, "up", "-d")
+	cmd.Dir = workDir
+	cmd.Run()
 }
 
 func parseRepositoryURL(repoURL string) (*RepositoryInfo, error) {

--- a/internal/daemon/workspace_init.go
+++ b/internal/daemon/workspace_init.go
@@ -751,6 +751,10 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 		fmt.Printf("OAuth is enabled for the Editor.\n")
 	}
 
+	// Initialize VPN automatically — editor and internal services
+	// should only be accessible through the VPN by default.
+	initVPNAutomatically(*domain, *verbose, os.Stdout)
+
 	return nil
 }
 
@@ -898,91 +902,89 @@ func saveMetadata(gitopsConfig, workspaceName, token, domain string, noIde bool,
 		return fmt.Errorf("failed to save metadata: %w", err)
 	}
 
-	// Initialize VPN automatically — editor and internal services should
-	// only be accessible through the VPN by default.
-	if !IsVPNEnabled() {
-		fmt.Fprintln(writer, "Initializing VPN...")
+	return nil
+}
 
-		// Auto-detect public IP for VPN endpoint
-		vpnEndpoint := detectPublicIPForVPN()
-		if vpnEndpoint == "" {
-			fmt.Fprintln(writer, "Warning: Could not detect public IP for VPN. Run 'bitswan vpn init --endpoint <ip>' manually.")
-		} else {
-			// Ensure server name exists
-			cfg := config.NewAutomationServerConfig()
-			serverConfig, _ := cfg.LoadConfig()
-			if serverConfig != nil && serverConfig.Slug == "" {
-				cfg.SetNameAndSlug(config.GenerateRandomName())
-			}
-			if serverConfig != nil && serverConfig.Domain == "" {
-				cfg.SetDomain(domain)
-			}
+// initVPNAutomatically sets up WireGuard VPN during workspace init.
+func initVPNAutomatically(domain string, verbose bool, writer io.Writer) {
+	if IsVPNEnabled() {
+		return
+	}
 
-			homeDir := os.Getenv("HOME")
-			vpnPath := filepath.Join(homeDir, ".config", "bitswan", "vpn")
-			vpnTraefikPath := filepath.Join(homeDir, ".config", "bitswan", "traefik-vpn")
-			hostHome := os.Getenv("HOST_HOME")
-			hostVpnPath := vpnPath
-			hostVpnTraefikPath := vpnTraefikPath
-			if hostHome != "" {
-				hostVpnPath = filepath.Join(hostHome, ".config", "bitswan", "vpn")
-				hostVpnTraefikPath = filepath.Join(hostHome, ".config", "bitswan", "traefik-vpn")
-			}
+	fmt.Fprintln(writer, "Initializing VPN...")
 
-			mgr := vpn.NewManager(filepath.Join(homeDir, ".config", "bitswan"))
-			if !mgr.IsInitialized() {
-				if err := mgr.Init(vpnEndpoint); err != nil {
-					fmt.Fprintf(writer, "Warning: VPN init failed: %v\n", err)
-				}
-			}
+	vpnEndpoint := detectPublicIPForVPN()
+	if vpnEndpoint == "" {
+		fmt.Fprintln(writer, "Warning: Could not detect public IP for VPN. Run 'bitswan vpn init --endpoint <ip>' manually.")
+		return
+	}
 
-			// Create VPN network
-			docker.EnsureDockerNetwork("bitswan_vpn_network", *verbose)
+	cfg := config.NewAutomationServerConfig()
+	serverConfig, _ := cfg.LoadConfig()
+	if serverConfig != nil && serverConfig.Slug == "" {
+		cfg.SetNameAndSlug(config.GenerateRandomName())
+	}
+	if serverConfig != nil && serverConfig.Domain == "" {
+		cfg.SetDomain(domain)
+	}
 
-			// Start WireGuard
-			wgCompose, _ := dockercompose.CreateWireGuardDockerComposeFile(hostVpnPath, 51820)
-			if wgCompose != "" {
-				dockerComposeUpQuiet("wireguard", wgCompose, vpnPath)
-			}
+	homeDir := os.Getenv("HOME")
+	vpnPath := filepath.Join(homeDir, ".config", "bitswan", "vpn")
+	vpnTraefikPath := filepath.Join(homeDir, ".config", "bitswan", "traefik-vpn")
+	hostHome := os.Getenv("HOST_HOME")
+	hostVpnPath := vpnPath
+	hostVpnTraefikPath := vpnTraefikPath
+	if hostHome != "" {
+		hostVpnPath = filepath.Join(hostHome, ".config", "bitswan", "vpn")
+		hostVpnTraefikPath = filepath.Join(hostHome, ".config", "bitswan", "traefik-vpn")
+	}
 
-			// Start VPN Traefik
-			os.MkdirAll(vpnTraefikPath, 0755)
-			traefikYml := "entryPoints:\n  web:\n    address: \":80\"\napi:\n  insecure: true\nproviders:\n  rest:\n    insecure: true\n"
-			os.WriteFile(filepath.Join(vpnTraefikPath, "traefik.yml"), []byte(traefikYml), 0644)
-			vpnTraefikCompose, _ := dockercompose.CreateVPNTraefikDockerComposeFile(hostVpnTraefikPath)
-			if vpnTraefikCompose != "" {
-				dockerComposeUpQuiet("traefik-vpn", vpnTraefikCompose, vpnTraefikPath)
-			}
-
-			// Start CoreDNS
-			dockercompose.WriteCorefile(vpnPath, "")
-			corednsCompose, _ := dockercompose.CreateCoreDNSDockerComposeFile(hostVpnPath)
-			if corednsCompose != "" {
-				dockerComposeUpQuiet("coredns-vpn", corednsCompose, vpnPath)
-			}
-
-			// Register VPN admin routes
-			serverConfig, _ = cfg.LoadConfig()
-			if serverConfig != nil {
-				internalDomain := serverConfig.InternalDomain()
-				addRouteToIngress(IngressAddRouteRequest{
-					Hostname:      "vpn-admin." + domain,
-					Upstream:      "bitswan-automation-server-daemon:8080",
-					IngressTarget: "external",
-				}, "")
-				addRouteToIngress(IngressAddRouteRequest{
-					Hostname:      "vpn-admin." + internalDomain,
-					Upstream:      "bitswan-automation-server-daemon:8080",
-					IngressTarget: "internal",
-				}, "")
-			}
-
-			fmt.Fprintf(writer, "VPN initialized (endpoint: %s)\n", vpnEndpoint)
-			fmt.Fprintln(writer, "Run 'bitswan vpn bootstrap' to download your VPN config.")
+	mgr := vpn.NewManager(filepath.Join(homeDir, ".config", "bitswan"))
+	if !mgr.IsInitialized() {
+		if err := mgr.Init(vpnEndpoint); err != nil {
+			fmt.Fprintf(writer, "Warning: VPN init failed: %v\n", err)
+			return
 		}
 	}
 
-	return nil
+	docker.EnsureDockerNetwork("bitswan_vpn_network", verbose)
+
+	wgCompose, _ := dockercompose.CreateWireGuardDockerComposeFile(hostVpnPath, 51820)
+	if wgCompose != "" {
+		dockerComposeUpQuiet("wireguard", wgCompose, vpnPath)
+	}
+
+	os.MkdirAll(vpnTraefikPath, 0755)
+	traefikYml := "entryPoints:\n  web:\n    address: \":80\"\napi:\n  insecure: true\nproviders:\n  rest:\n    insecure: true\n"
+	os.WriteFile(filepath.Join(vpnTraefikPath, "traefik.yml"), []byte(traefikYml), 0644)
+	vpnTraefikCompose, _ := dockercompose.CreateVPNTraefikDockerComposeFile(hostVpnTraefikPath)
+	if vpnTraefikCompose != "" {
+		dockerComposeUpQuiet("traefik-vpn", vpnTraefikCompose, vpnTraefikPath)
+	}
+
+	dockercompose.WriteCorefile(vpnPath, "")
+	corednsCompose, _ := dockercompose.CreateCoreDNSDockerComposeFile(hostVpnPath)
+	if corednsCompose != "" {
+		dockerComposeUpQuiet("coredns-vpn", corednsCompose, vpnPath)
+	}
+
+	serverConfig, _ = cfg.LoadConfig()
+	if serverConfig != nil {
+		internalDomain := serverConfig.InternalDomain()
+		addRouteToIngress(IngressAddRouteRequest{
+			Hostname:      "vpn-admin." + domain,
+			Upstream:      "bitswan-automation-server-daemon:8080",
+			IngressTarget: "external",
+		}, "")
+		addRouteToIngress(IngressAddRouteRequest{
+			Hostname:      "vpn-admin." + internalDomain,
+			Upstream:      "bitswan-automation-server-daemon:8080",
+			IngressTarget: "internal",
+		}, "")
+	}
+
+	fmt.Fprintf(writer, "VPN initialized (endpoint: %s)\n", vpnEndpoint)
+	fmt.Fprintln(writer, "Run 'bitswan vpn bootstrap' to download your VPN config.")
 }
 
 func detectPublicIPForVPN() string {

--- a/internal/daemon/workspace_init.go
+++ b/internal/daemon/workspace_init.go
@@ -67,6 +67,16 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 	// Init bitswan network
 	docker.EnsureDockerNetwork("bitswan_network", *verbose)
 
+	// Create per-workspace stage networks for isolation
+	stageNetworks := []string{
+		workspaceName + "-dev",
+		workspaceName + "-staging",
+		workspaceName + "-production",
+	}
+	for _, net := range stageNetworks {
+		docker.EnsureDockerNetwork(net, *verbose)
+	}
+
 	var oauthConfig *oauth.Config
 	if *oauthConfigFile != "" {
 		oauthConfig, err = oauth.GetInitOauthConfig(*oauthConfigFile)

--- a/internal/daemon/workspace_remove.go
+++ b/internal/daemon/workspace_remove.go
@@ -145,7 +145,16 @@ func RunWorkspaceRemove(workspaceName string, writer io.Writer) error {
 	}()
 	// Continue immediately - don't wait for ingress cleanup
 
-	// 6. Remove the gitops folder
+	// 6. Remove per-workspace stage networks
+	for _, stage := range []string{"dev", "staging", "production"} {
+		netName := workspaceName + "-" + stage
+		rmCmd := exec.Command("docker", "network", "rm", netName)
+		if err := rmCmd.Run(); err != nil {
+			fmt.Fprintf(writer, "Warning: Failed to remove network %s: %v\n", netName, err)
+		}
+	}
+
+	// 7. Remove the gitops folder
 	workspaceDir := filepath.Join(workspacesFolder, workspaceName)
 	if _, err := os.Stat(workspaceDir); os.IsNotExist(err) {
 		fmt.Fprintf(writer, "Warning: Workspace directory %s does not exist, nothing to remove.\n", workspaceDir)

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -93,6 +93,7 @@ func (config *DockerComposeConfig) CreateDockerComposeFileWithSecret(existingSec
 			"BITSWAN_GITOPS_SECRET=" + gitopsSecretToken,
 			"BITSWAN_GITOPS_DOMAIN=" + config.Domain,
 			"BITSWAN_WORKSPACE_NAME=" + config.WorkspaceName,
+			"BITSWAN_STAGE_NETWORKS=true",
 			"BITSWAN_CERTS_DIR=" + homeDir + "/.config/bitswan/certauthorities",
 		},
 	}

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -316,17 +316,12 @@ func CreateVPNTraefikDockerComposeFile(traefikPath string) (string, error) {
 	return buf.String(), nil
 }
 
-// CreateCoreDNSDockerComposeFile creates a docker-compose file for the VPN DNS server.
-// It resolves *.bswn.internal to the VPN Traefik container so VPN clients
-// can access internal services via the fake TLD.
-// vpnPath: path to VPN config directory (Corefile will be written here)
-// vpnTraefikIP: IP address of the VPN Traefik on bitswan_vpn_network
-func CreateCoreDNSDockerComposeFile(vpnPath string, vpnTraefikIP string) (string, error) {
+// WriteCorefile writes the CoreDNS Corefile to the local VPN config directory.
+// localVpnPath: daemon-local path (e.g., /root/.config/bitswan/vpn)
+func WriteCorefile(localVpnPath string, vpnTraefikIP string) error {
 	if vpnTraefikIP == "" {
 		vpnTraefikIP = "10.8.0.3"
 	}
-
-	// Write Corefile
 	corefile := fmt.Sprintf(`bswn.internal {
     template IN A {
         answer "{{ .Name }} 60 IN A %s"
@@ -338,15 +333,16 @@ func CreateCoreDNSDockerComposeFile(vpnPath string, vpnTraefikIP string) (string
     cache 30
 }
 `, vpnTraefikIP)
-
-	corefilePath := filepath.Join(vpnPath, "Corefile")
-	if err := os.MkdirAll(vpnPath, 0700); err != nil {
-		return "", fmt.Errorf("failed to create VPN config dir: %w", err)
+	corefilePath := filepath.Join(localVpnPath, "Corefile")
+	if err := os.MkdirAll(localVpnPath, 0700); err != nil {
+		return fmt.Errorf("failed to create VPN config dir: %w", err)
 	}
-	if err := os.WriteFile(corefilePath, []byte(corefile), 0644); err != nil {
-		return "", fmt.Errorf("failed to write Corefile: %w", err)
-	}
+	return os.WriteFile(corefilePath, []byte(corefile), 0644)
+}
 
+// CreateCoreDNSDockerComposeFile creates a docker-compose file for the VPN DNS server.
+// hostVpnPath: host path for volume mounts (e.g., /home/ubuntu/.config/bitswan/vpn)
+func CreateCoreDNSDockerComposeFile(hostVpnPath string) (string, error) {
 	dockerCompose := map[string]interface{}{
 		"version": "3.8",
 		"services": map[string]interface{}{
@@ -357,7 +353,7 @@ func CreateCoreDNSDockerComposeFile(vpnPath string, vpnTraefikIP string) (string
 				"command":        "-conf /etc/coredns/Corefile",
 				"networks":       []string{"bitswan_vpn_network"},
 				"volumes": []string{
-					vpnPath + "/Corefile:/etc/coredns/Corefile:ro",
+					hostVpnPath + "/Corefile:/etc/coredns/Corefile:ro",
 				},
 			},
 		},

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -315,6 +315,58 @@ func CreateVPNTraefikDockerComposeFile(traefikPath string) (string, error) {
 	return buf.String(), nil
 }
 
+// CreateWireGuardDockerComposeFile creates a docker-compose file for the WireGuard VPN server.
+// vpnPath: path to VPN config directory (e.g., ~/.config/bitswan/vpn)
+// listenPort: UDP port for WireGuard (default 51820)
+func CreateWireGuardDockerComposeFile(vpnPath string, listenPort int) (string, error) {
+	if listenPort == 0 {
+		listenPort = 51820
+	}
+
+	dockerCompose := map[string]interface{}{
+		"version": "3.8",
+		"services": map[string]interface{}{
+			"wireguard": map[string]interface{}{
+				"image":          "linuxserver/wireguard:latest",
+				"restart":        "always",
+				"container_name": "wireguard",
+				"cap_add":        []string{"NET_ADMIN", "SYS_MODULE"},
+				"ports":          []string{fmt.Sprintf("%d:%d/udp", listenPort, listenPort)},
+				"networks":       []string{"bitswan_network", "bitswan_vpn_network"},
+				"environment": []string{
+					"PUID=1000",
+					"PGID=1000",
+				},
+				"volumes": []string{
+					vpnPath + ":/config:z",
+					"/lib/modules:/lib/modules:ro",
+				},
+				"sysctls": []string{
+					"net.ipv4.conf.all.src_valid_mark=1",
+					"net.ipv4.ip_forward=1",
+				},
+			},
+		},
+		"networks": map[string]interface{}{
+			"bitswan_network": map[string]interface{}{
+				"external": true,
+			},
+			"bitswan_vpn_network": map[string]interface{}{
+				"external": true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(dockerCompose); err != nil {
+		return "", fmt.Errorf("failed to encode docker-compose data structure: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
 // CreateWorkspaceTraefikDockerComposeFile creates a docker-compose file for workspace sub-traefik.
 // workspaceName: name of the workspace (used for container name)
 // traefikPath: path to traefik config directory

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -275,6 +275,46 @@ func CreateTraefikDockerComposeFile(traefikPath string, networks ...string) (str
 	return buf.String(), nil
 }
 
+// CreateVPNTraefikDockerComposeFile creates a docker-compose file for the VPN-internal Traefik.
+// It has no host ports — only reachable from VPN clients via the WireGuard server.
+// traefikPath: path to the VPN traefik config directory (e.g., ~/.config/bitswan/traefik-vpn)
+func CreateVPNTraefikDockerComposeFile(traefikPath string) (string, error) {
+	traefikVolumes := []string{
+		traefikPath + "/traefik.yml:/etc/traefik/traefik.yml:z",
+	}
+
+	dockerCompose := map[string]interface{}{
+		"version": "3.8",
+		"services": map[string]interface{}{
+			"traefik-vpn": map[string]interface{}{
+				"image":          "traefik:v3.6",
+				"restart":        "always",
+				"container_name": "traefik-vpn",
+				// No host ports — only reachable from VPN subnet
+				"networks": []string{"bitswan_network", "bitswan_vpn_network"},
+				"volumes":  traefikVolumes,
+			},
+		},
+		"networks": map[string]interface{}{
+			"bitswan_network": map[string]interface{}{
+				"external": true,
+			},
+			"bitswan_vpn_network": map[string]interface{}{
+				"external": true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(dockerCompose); err != nil {
+		return "", fmt.Errorf("failed to encode docker-compose data structure: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
 // CreateWorkspaceTraefikDockerComposeFile creates a docker-compose file for workspace sub-traefik.
 // workspaceName: name of the workspace (used for container name)
 // traefikPath: path to traefik config directory

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -299,6 +300,68 @@ func CreateVPNTraefikDockerComposeFile(traefikPath string) (string, error) {
 			"bitswan_network": map[string]interface{}{
 				"external": true,
 			},
+			"bitswan_vpn_network": map[string]interface{}{
+				"external": true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(dockerCompose); err != nil {
+		return "", fmt.Errorf("failed to encode docker-compose data structure: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// CreateCoreDNSDockerComposeFile creates a docker-compose file for the VPN DNS server.
+// It resolves *.bswn.internal to the VPN Traefik container so VPN clients
+// can access internal services via the fake TLD.
+// vpnPath: path to VPN config directory (Corefile will be written here)
+// vpnTraefikIP: IP address of the VPN Traefik on bitswan_vpn_network
+func CreateCoreDNSDockerComposeFile(vpnPath string, vpnTraefikIP string) (string, error) {
+	if vpnTraefikIP == "" {
+		vpnTraefikIP = "10.8.0.3"
+	}
+
+	// Write Corefile
+	corefile := fmt.Sprintf(`bswn.internal {
+    template IN A {
+        answer "{{ .Name }} 60 IN A %s"
+    }
+}
+
+. {
+    forward . 8.8.8.8 8.8.4.4
+    cache 30
+}
+`, vpnTraefikIP)
+
+	corefilePath := filepath.Join(vpnPath, "Corefile")
+	if err := os.MkdirAll(vpnPath, 0700); err != nil {
+		return "", fmt.Errorf("failed to create VPN config dir: %w", err)
+	}
+	if err := os.WriteFile(corefilePath, []byte(corefile), 0644); err != nil {
+		return "", fmt.Errorf("failed to write Corefile: %w", err)
+	}
+
+	dockerCompose := map[string]interface{}{
+		"version": "3.8",
+		"services": map[string]interface{}{
+			"coredns-vpn": map[string]interface{}{
+				"image":          "coredns/coredns:latest",
+				"restart":        "always",
+				"container_name": "coredns-vpn",
+				"command":        "-conf /etc/coredns/Corefile",
+				"networks":       []string{"bitswan_vpn_network"},
+				"volumes": []string{
+					vpnPath + "/Corefile:/etc/coredns/Corefile:ro",
+				},
+			},
+		},
+		"networks": map[string]interface{}{
 			"bitswan_vpn_network": map[string]interface{}{
 				"external": true,
 			},

--- a/internal/vpn/magiclink.go
+++ b/internal/vpn/magiclink.go
@@ -1,0 +1,186 @@
+package vpn
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	magicLinkFile    = "magic-links.json"
+	magicLinkExpiry  = 1 * time.Hour
+	magicLinkTokenLen = 32 // 32 bytes = 64 hex chars
+)
+
+// MagicLink represents a one-time-use VPN credential download token.
+type MagicLink struct {
+	Token     string    `json:"token"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+	Claimed   bool      `json:"claimed"`
+	ClaimedBy string    `json:"claimed_by,omitempty"`
+}
+
+// MagicLinkStore manages magic link tokens on disk.
+type MagicLinkStore struct {
+	baseDir string
+	mu      sync.Mutex
+}
+
+// NewMagicLinkStore creates a store rooted at the VPN config directory.
+func NewMagicLinkStore(bitswanConfigDir string) *MagicLinkStore {
+	return &MagicLinkStore{
+		baseDir: filepath.Join(bitswanConfigDir, vpnDirName),
+	}
+}
+
+// Create generates a new magic link token.
+func (s *MagicLinkStore) Create(createdBy string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tokenBytes := make([]byte, magicLinkTokenLen)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return "", fmt.Errorf("failed to generate token: %w", err)
+	}
+	token := hex.EncodeToString(tokenBytes)
+
+	now := time.Now().UTC()
+	link := MagicLink{
+		Token:     token,
+		CreatedBy: createdBy,
+		CreatedAt: now,
+		ExpiresAt: now.Add(magicLinkExpiry),
+		Claimed:   false,
+	}
+
+	links, _ := s.readLinks()
+	links = append(links, link)
+	if err := s.writeLinks(links); err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+// Validate checks if a token is valid (exists, not expired, not claimed).
+func (s *MagicLinkStore) Validate(token string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	links, err := s.readLinks()
+	if err != nil {
+		return fmt.Errorf("failed to read magic links: %w", err)
+	}
+
+	for _, link := range links {
+		if link.Token == token {
+			if link.Claimed {
+				return fmt.Errorf("token already claimed")
+			}
+			if time.Now().UTC().After(link.ExpiresAt) {
+				return fmt.Errorf("token expired")
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("token not found")
+}
+
+// Claim marks a token as claimed and returns the creator info.
+func (s *MagicLinkStore) Claim(token, claimedBy string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	links, err := s.readLinks()
+	if err != nil {
+		return fmt.Errorf("failed to read magic links: %w", err)
+	}
+
+	for i, link := range links {
+		if link.Token == token {
+			if link.Claimed {
+				return fmt.Errorf("token already claimed")
+			}
+			if time.Now().UTC().After(link.ExpiresAt) {
+				return fmt.Errorf("token expired")
+			}
+			links[i].Claimed = true
+			links[i].ClaimedBy = claimedBy
+			return s.writeLinks(links)
+		}
+	}
+	return fmt.Errorf("token not found")
+}
+
+// CleanupExpired removes expired and claimed tokens.
+func (s *MagicLinkStore) CleanupExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	links, err := s.readLinks()
+	if err != nil {
+		return
+	}
+
+	now := time.Now().UTC()
+	var active []MagicLink
+	for _, link := range links {
+		if !link.Claimed && now.Before(link.ExpiresAt) {
+			active = append(active, link)
+		}
+	}
+	s.writeLinks(active)
+}
+
+// List returns all active (unclaimed, unexpired) magic links.
+func (s *MagicLinkStore) List() ([]MagicLink, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	links, err := s.readLinks()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	var active []MagicLink
+	for _, link := range links {
+		if !link.Claimed && now.Before(link.ExpiresAt) {
+			active = append(active, link)
+		}
+	}
+	return active, nil
+}
+
+func (s *MagicLinkStore) readLinks() ([]MagicLink, error) {
+	filePath := filepath.Join(s.baseDir, magicLinkFile)
+	data, err := os.ReadFile(filePath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var links []MagicLink
+	if err := json.Unmarshal(data, &links); err != nil {
+		return nil, err
+	}
+	return links, nil
+}
+
+func (s *MagicLinkStore) writeLinks(links []MagicLink) error {
+	filePath := filepath.Join(s.baseDir, magicLinkFile)
+	os.MkdirAll(s.baseDir, 0700)
+	data, err := json.MarshalIndent(links, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, data, 0600)
+}

--- a/internal/vpn/session_monitor.go
+++ b/internal/vpn/session_monitor.go
@@ -23,7 +23,8 @@ type SessionEvent struct {
 	DeviceID   string `json:"device_id"`
 	UserID     string `json:"user_id"`
 	DeviceName string `json:"device_name"`
-	Event      string `json:"event"` // "handshake", "connected", "disconnected"
+	Event      string `json:"event"` // "handshake", "connected", "disconnected", "unclassified"
+	Classified bool   `json:"classified"` // false = could not match to a known device
 	Timestamp  string `json:"timestamp"`
 	SourceIP   string `json:"source_ip,omitempty"`
 	PublicKey  string `json:"public_key"`
@@ -205,13 +206,16 @@ func (sm *SessionMonitor) onHandshakeDetected(sourceIP string) {
 	// Run wg show to get current peer states
 	peers, err := sm.getWgShowDump()
 	if err != nil {
+		// Can't enrich — log as unclassified
+		sm.emitEvent("", "unclassified", sourceIP, 0, 0)
 		return
 	}
 
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	now := time.Now().UTC()
+	// Track whether any peer had a state change matching this handshake
+	matched := false
 
 	for _, peer := range peers {
 		existing, ok := sm.peerStates[peer.PublicKey]
@@ -226,6 +230,7 @@ func (sm *SessionMonitor) onHandshakeDetected(sourceIP string) {
 				Connected:    !peer.LastHandshake.IsZero(),
 			}
 			if !peer.LastHandshake.IsZero() {
+				matched = true
 				sm.emitEvent(peer.PublicKey, "connected", sourceIP, peer.TransferRx, peer.TransferTx)
 			}
 			continue
@@ -233,6 +238,7 @@ func (sm *SessionMonitor) onHandshakeDetected(sourceIP string) {
 
 		// Check if handshake timestamp changed (new handshake)
 		if peer.LastHandshake.After(existing.LastHandshake) {
+			matched = true
 			wasConnected := existing.Connected
 			existing.LastHandshake = peer.LastHandshake
 			existing.TransferRx = peer.TransferRx
@@ -248,7 +254,13 @@ func (sm *SessionMonitor) onHandshakeDetected(sourceIP string) {
 		// Update transfer counters regardless
 		existing.TransferRx = peer.TransferRx
 		existing.TransferTx = peer.TransferTx
-		_ = now
+	}
+
+	// Iptables saw a handshake packet but no peer state changed.
+	// Could be a failed handshake attempt from an unknown key,
+	// a replay, or a timing edge case.
+	if !matched {
+		sm.emitEvent("", "unclassified", sourceIP, 0, 0)
 	}
 }
 
@@ -284,6 +296,7 @@ func (sm *SessionMonitor) emitEvent(publicKey, event, sourceIP string, rx, tx in
 
 	sessionEvent := SessionEvent{
 		Event:      event,
+		Classified: device != nil,
 		Timestamp:  time.Now().UTC().Format(time.RFC3339),
 		SourceIP:   sourceIP,
 		PublicKey:  publicKey,

--- a/internal/vpn/session_monitor.go
+++ b/internal/vpn/session_monitor.go
@@ -1,0 +1,379 @@
+package vpn
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	handshakeTimeout = 3 * time.Minute // no handshake for 3 min = offline
+	sessionLogFile   = "sessions.jsonl"
+	iptablesPrefix   = "WG-HANDSHAKE: "
+)
+
+// SessionEvent represents a single enriched VPN session event.
+type SessionEvent struct {
+	DeviceID   string `json:"device_id"`
+	UserID     string `json:"user_id"`
+	DeviceName string `json:"device_name"`
+	Event      string `json:"event"` // "handshake", "connected", "disconnected"
+	Timestamp  string `json:"timestamp"`
+	SourceIP   string `json:"source_ip,omitempty"`
+	PublicKey  string `json:"public_key"`
+	IP         string `json:"ip"`
+	TransferRx int64  `json:"transfer_rx"`
+	TransferTx int64  `json:"transfer_tx"`
+}
+
+// PeerState tracks the last known state of a WireGuard peer.
+type PeerState struct {
+	PublicKey      string
+	LastHandshake  time.Time
+	TransferRx    int64
+	TransferTx    int64
+	Connected     bool
+}
+
+// SessionMonitor watches for WireGuard handshakes via iptables log
+// and enriches them with wg show data.
+type SessionMonitor struct {
+	manager    *Manager
+	logPath    string // path to sessions.jsonl
+	peerStates map[string]*PeerState // pubkey → state
+	mu         sync.Mutex
+	stopCh     chan struct{}
+}
+
+// NewSessionMonitor creates a monitor that writes to the VPN config dir.
+func NewSessionMonitor(manager *Manager) *SessionMonitor {
+	return &SessionMonitor{
+		manager:    manager,
+		logPath:    filepath.Join(manager.baseDir, sessionLogFile),
+		peerStates: make(map[string]*PeerState),
+		stopCh:     make(chan struct{}),
+	}
+}
+
+// Start begins monitoring. Call in a goroutine.
+// It sets up the iptables rule, tails the kernel log, and enriches events.
+func (sm *SessionMonitor) Start() error {
+	// Ensure iptables LOG rule exists
+	if err := sm.ensureIptablesRule(); err != nil {
+		return fmt.Errorf("failed to set up iptables logging: %w", err)
+	}
+
+	// Start two goroutines:
+	// 1. Tail kernel log for handshake packets → trigger enrichment
+	// 2. Periodic disconnect checker (detect peers that went silent)
+	go sm.tailKernelLog()
+	go sm.disconnectChecker()
+
+	return nil
+}
+
+// Stop shuts down the monitor.
+func (sm *SessionMonitor) Stop() {
+	close(sm.stopCh)
+}
+
+// GetActiveSessions returns currently connected devices.
+func (sm *SessionMonitor) GetActiveSessions() []SessionEvent {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	var active []SessionEvent
+	for _, state := range sm.peerStates {
+		if !state.Connected {
+			continue
+		}
+		device := sm.lookupDevice(state.PublicKey)
+		if device == nil {
+			continue
+		}
+		active = append(active, SessionEvent{
+			DeviceID:   device.DeviceID,
+			UserID:     device.UserID,
+			DeviceName: device.DeviceName,
+			Event:      "active",
+			Timestamp:  state.LastHandshake.Format(time.RFC3339),
+			PublicKey:  state.PublicKey,
+			IP:         device.IP,
+			TransferRx: state.TransferRx,
+			TransferTx: state.TransferTx,
+		})
+	}
+	return active
+}
+
+// GetSessionLog returns recent session events from the log file.
+func (sm *SessionMonitor) GetSessionLog(limit int) ([]SessionEvent, error) {
+	data, err := os.ReadFile(sm.logPath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	var events []SessionEvent
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var event SessionEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		events = append(events, event)
+	}
+
+	// Return last N events
+	if limit > 0 && len(events) > limit {
+		events = events[len(events)-limit:]
+	}
+	return events, nil
+}
+
+// --- Internal ---
+
+func (sm *SessionMonitor) ensureIptablesRule() error {
+	// Check if rule already exists
+	check := exec.Command("docker", "exec", "wireguard",
+		"iptables", "-C", "INPUT", "-p", "udp", "--dport", "51820",
+		"-j", "LOG", "--log-prefix", iptablesPrefix)
+	if check.Run() == nil {
+		return nil // already exists
+	}
+
+	// Add the rule
+	add := exec.Command("docker", "exec", "wireguard",
+		"iptables", "-A", "INPUT", "-p", "udp", "--dport", "51820",
+		"-j", "LOG", "--log-prefix", iptablesPrefix)
+	out, err := add.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", err, string(out))
+	}
+	return nil
+}
+
+func (sm *SessionMonitor) tailKernelLog() {
+	// Tail the kernel log from the wireguard container
+	cmd := exec.Command("docker", "exec", "wireguard",
+		"tail", "-n", "0", "-F", "/proc/kmsg")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "session monitor: failed to tail kernel log: %v\n", err)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "session monitor: failed to start tail: %v\n", err)
+		return
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		select {
+		case <-sm.stopCh:
+			cmd.Process.Kill()
+			return
+		default:
+		}
+
+		line := scanner.Text()
+		if !strings.Contains(line, iptablesPrefix) {
+			continue
+		}
+
+		// Extract source IP from iptables log line
+		sourceIP := extractSourceIP(line)
+
+		// Handshake detected — enrich with wg show
+		sm.onHandshakeDetected(sourceIP)
+	}
+}
+
+func (sm *SessionMonitor) onHandshakeDetected(sourceIP string) {
+	// Run wg show to get current peer states
+	peers, err := sm.getWgShowDump()
+	if err != nil {
+		return
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	now := time.Now().UTC()
+
+	for _, peer := range peers {
+		existing, ok := sm.peerStates[peer.PublicKey]
+
+		if !ok {
+			// New peer
+			sm.peerStates[peer.PublicKey] = &PeerState{
+				PublicKey:     peer.PublicKey,
+				LastHandshake: peer.LastHandshake,
+				TransferRx:   peer.TransferRx,
+				TransferTx:   peer.TransferTx,
+				Connected:    !peer.LastHandshake.IsZero(),
+			}
+			if !peer.LastHandshake.IsZero() {
+				sm.emitEvent(peer.PublicKey, "connected", sourceIP, peer.TransferRx, peer.TransferTx)
+			}
+			continue
+		}
+
+		// Check if handshake timestamp changed (new handshake)
+		if peer.LastHandshake.After(existing.LastHandshake) {
+			wasConnected := existing.Connected
+			existing.LastHandshake = peer.LastHandshake
+			existing.TransferRx = peer.TransferRx
+			existing.TransferTx = peer.TransferTx
+			existing.Connected = true
+
+			if !wasConnected {
+				sm.emitEvent(peer.PublicKey, "connected", sourceIP, peer.TransferRx, peer.TransferTx)
+			}
+			sm.emitEvent(peer.PublicKey, "handshake", sourceIP, peer.TransferRx, peer.TransferTx)
+		}
+
+		// Update transfer counters regardless
+		existing.TransferRx = peer.TransferRx
+		existing.TransferTx = peer.TransferTx
+		_ = now
+	}
+}
+
+func (sm *SessionMonitor) disconnectChecker() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-sm.stopCh:
+			return
+		case <-ticker.C:
+			sm.checkDisconnects()
+		}
+	}
+}
+
+func (sm *SessionMonitor) checkDisconnects() {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	now := time.Now().UTC()
+	for pubkey, state := range sm.peerStates {
+		if state.Connected && now.Sub(state.LastHandshake) > handshakeTimeout {
+			state.Connected = false
+			sm.emitEvent(pubkey, "disconnected", "", state.TransferRx, state.TransferTx)
+		}
+	}
+}
+
+func (sm *SessionMonitor) emitEvent(publicKey, event, sourceIP string, rx, tx int64) {
+	device := sm.lookupDevice(publicKey)
+
+	sessionEvent := SessionEvent{
+		Event:      event,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		SourceIP:   sourceIP,
+		PublicKey:  publicKey,
+		TransferRx: rx,
+		TransferTx: tx,
+	}
+	if device != nil {
+		sessionEvent.DeviceID = device.DeviceID
+		sessionEvent.UserID = device.UserID
+		sessionEvent.DeviceName = device.DeviceName
+		sessionEvent.IP = device.IP
+	}
+
+	// Append to JSONL log
+	data, _ := json.Marshal(sessionEvent)
+	f, err := os.OpenFile(sm.logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	f.Write(data)
+	f.WriteString("\n")
+}
+
+func (sm *SessionMonitor) lookupDevice(publicKey string) *VPNDevice {
+	devices, _ := sm.manager.ListDevices()
+	for _, d := range devices {
+		if d.PublicKey == publicKey {
+			return &d
+		}
+	}
+	return nil
+}
+
+// wgPeer represents a peer from `wg show dump` output.
+type wgPeer struct {
+	PublicKey     string
+	LastHandshake time.Time
+	TransferRx   int64
+	TransferTx   int64
+}
+
+func (sm *SessionMonitor) getWgShowDump() ([]wgPeer, error) {
+	cmd := exec.Command("docker", "exec", "wireguard", "wg", "show", "wg0", "dump")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var peers []wgPeer
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for i, line := range lines {
+		if i == 0 {
+			continue // skip header (interface line)
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 7 {
+			continue
+		}
+		// Fields: public_key, preshared_key, endpoint, allowed_ips, latest_handshake, transfer_rx, transfer_tx
+		var handshakeTime time.Time
+		if ts := fields[4]; ts != "0" {
+			var epoch int64
+			fmt.Sscanf(ts, "%d", &epoch)
+			if epoch > 0 {
+				handshakeTime = time.Unix(epoch, 0).UTC()
+			}
+		}
+		var rx, tx int64
+		fmt.Sscanf(fields[5], "%d", &rx)
+		fmt.Sscanf(fields[6], "%d", &tx)
+
+		peers = append(peers, wgPeer{
+			PublicKey:     fields[0],
+			LastHandshake: handshakeTime,
+			TransferRx:   rx,
+			TransferTx:   tx,
+		})
+	}
+	return peers, nil
+}
+
+func extractSourceIP(logLine string) string {
+	// iptables LOG format: ... SRC=1.2.3.4 DST=...
+	if idx := strings.Index(logLine, "SRC="); idx >= 0 {
+		rest := logLine[idx+4:]
+		if end := strings.IndexByte(rest, ' '); end >= 0 {
+			return rest[:end]
+		}
+		return rest
+	}
+	return ""
+}

--- a/internal/vpn/wireguard.go
+++ b/internal/vpn/wireguard.go
@@ -1,10 +1,10 @@
 package vpn
 
 import (
+	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -311,42 +311,15 @@ func (m *Manager) removePeerFromServerConfig(publicKey string) error {
 }
 
 func generateKeyPair() (privateKey, publicKey string, err error) {
-	// Try using wg command if available
-	privCmd := exec.Command("wg", "genkey")
-	privOut, err := privCmd.Output()
-	if err == nil {
-		priv := strings.TrimSpace(string(privOut))
-		pubCmd := exec.Command("wg", "pubkey")
-		pubCmd.Stdin = strings.NewReader(priv)
-		pubOut, err := pubCmd.Output()
-		if err == nil {
-			return priv, strings.TrimSpace(string(pubOut)), nil
-		}
-	}
-
-	// Fallback: generate Curve25519 keypair manually
-	var private [32]byte
-	if _, err := rand.Read(private[:]); err != nil {
-		return "", "", err
-	}
-	// Clamp private key per Curve25519 spec
-	private[0] &= 248
-	private[31] &= 127
-	private[31] |= 64
-
-	priv := base64.StdEncoding.EncodeToString(private[:])
-
-	// Compute public key via Curve25519 scalar multiplication
-	// For simplicity, shell out to wg pubkey if available, otherwise error
-	pubCmd := exec.Command("wg", "pubkey")
-	pubCmd.Stdin = strings.NewReader(priv)
-	pubOut, err := pubCmd.Output()
+	// Pure Go X25519 key generation via crypto/ecdh — no wg binary needed
+	key, err := ecdh.X25519().GenerateKey(rand.Reader)
 	if err != nil {
-		return "", "", fmt.Errorf("wg command not available for key generation: %w", err)
+		return "", "", fmt.Errorf("failed to generate X25519 key: %w", err)
 	}
 
-	return priv, strings.TrimSpace(string(pubOut)), nil
-}
+	privBytes := key.Bytes()
+	pubBytes := key.PublicKey().Bytes()
 
-// Silence unused import warning
-var _ = net.ParseCIDR
+	return base64.StdEncoding.EncodeToString(privBytes),
+		base64.StdEncoding.EncodeToString(pubBytes), nil
+}

--- a/internal/vpn/wireguard.go
+++ b/internal/vpn/wireguard.go
@@ -64,6 +64,7 @@ func (m *Manager) Init(serverEndpoint string) error {
 
 	os.MkdirAll(m.baseDir, 0700)
 	os.MkdirAll(filepath.Join(m.baseDir, usersDirName), 0700)
+	os.MkdirAll(filepath.Join(m.baseDir, "wg_confs"), 0700)
 
 	// Generate server keypair
 	serverPriv, serverPub, err := generateKeyPair()
@@ -87,7 +88,7 @@ PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -t nat -A POSTROUTING -o
 PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
 `, ServerIP, ListenPort, serverPriv)
 
-	if err := os.WriteFile(filepath.Join(m.baseDir, "wg0.conf"), []byte(conf), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(m.baseDir, "wg_confs", "wg0.conf"), []byte(conf), 0600); err != nil {
 		return err
 	}
 
@@ -267,7 +268,7 @@ func (m *Manager) ServerPublicKey() (string, error) {
 func (m *Manager) ReloadServer() error {
 	// docker exec wireguard wg syncconf wg0 <(wg-quick strip wg0)
 	cmd := exec.Command("docker", "exec", "wireguard", "bash", "-c",
-		"wg syncconf wg0 <(wg-quick strip /config/wg0.conf)")
+		"wg syncconf wg0 <(wg-quick strip /config/wg_confs/wg0.conf)")
 	return cmd.Run()
 }
 
@@ -291,7 +292,7 @@ func (m *Manager) nextAvailableIP() (string, error) {
 }
 
 func (m *Manager) addPeerToServerConfig(publicKey, ip string) error {
-	confPath := filepath.Join(m.baseDir, "wg0.conf")
+	confPath := filepath.Join(m.baseDir, "wg_confs", "wg0.conf")
 	f, err := os.OpenFile(confPath, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
@@ -308,7 +309,7 @@ func (m *Manager) addPeerToServerConfig(publicKey, ip string) error {
 }
 
 func (m *Manager) removePeerFromServerConfig(publicKey string) error {
-	confPath := filepath.Join(m.baseDir, "wg0.conf")
+	confPath := filepath.Join(m.baseDir, "wg_confs", "wg0.conf")
 	data, err := os.ReadFile(confPath)
 	if err != nil {
 		return err

--- a/internal/vpn/wireguard.go
+++ b/internal/vpn/wireguard.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -23,11 +24,14 @@ const (
 	usersDirName = "users"
 )
 
-// VPNUser represents a registered VPN user.
-type VPNUser struct {
-	ID        string `json:"id" yaml:"id"`
-	PublicKey string `json:"public_key" yaml:"public_key"`
-	IP        string `json:"ip" yaml:"ip"`
+// VPNDevice represents a single device registered to a user.
+type VPNDevice struct {
+	DeviceID   string `json:"device_id" yaml:"device_id"`     // unique: {user_id}/{device_name}
+	UserID     string `json:"user_id" yaml:"user_id"`
+	DeviceName string `json:"device_name" yaml:"device_name"` // e.g., "laptop", "phone"
+	PublicKey  string `json:"public_key" yaml:"public_key"`
+	IP         string `json:"ip" yaml:"ip"`
+	IssuedAt   string `json:"issued_at" yaml:"issued_at"`
 }
 
 // Manager handles WireGuard server and client configuration.
@@ -101,8 +105,10 @@ PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -t nat -D POSTROUTING 
 	return os.WriteFile(filepath.Join(m.baseDir, "enabled"), []byte("true\n"), 0644)
 }
 
-// GenerateClient creates a new VPN client and returns the client .conf content.
-func (m *Manager) GenerateClient(userID string) ([]byte, error) {
+// GenerateClient creates a new VPN device for a user and returns the client .conf content.
+// userID: the user (e.g., email or username)
+// deviceName: the device label (e.g., "laptop", "phone")
+func (m *Manager) GenerateClient(userID, deviceName string) ([]byte, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -110,9 +116,9 @@ func (m *Manager) GenerateClient(userID string) ([]byte, error) {
 		return nil, fmt.Errorf("VPN not initialized")
 	}
 
-	userDir := filepath.Join(m.baseDir, usersDirName, userID)
-	if _, err := os.Stat(userDir); err == nil {
-		return nil, fmt.Errorf("user %s already exists", userID)
+	deviceDir := filepath.Join(m.baseDir, usersDirName, userID, deviceName)
+	if _, err := os.Stat(deviceDir); err == nil {
+		return nil, fmt.Errorf("device %s/%s already exists", userID, deviceName)
 	}
 
 	// Read server metadata
@@ -137,16 +143,19 @@ func (m *Manager) GenerateClient(userID string) ([]byte, error) {
 		return nil, err
 	}
 
-	// Save client info
-	os.MkdirAll(userDir, 0700)
-	user := VPNUser{
-		ID:        userID,
-		PublicKey: clientPub,
-		IP:        clientIP,
+	// Save device info
+	os.MkdirAll(deviceDir, 0700)
+	device := VPNDevice{
+		DeviceID:   userID + "/" + deviceName,
+		UserID:     userID,
+		DeviceName: deviceName,
+		PublicKey:  clientPub,
+		IP:         clientIP,
+		IssuedAt:   fmt.Sprintf("%s", time.Now().UTC().Format(time.RFC3339)),
 	}
-	userBytes, _ := yaml.Marshal(user)
-	os.WriteFile(filepath.Join(userDir, "user.yaml"), userBytes, 0644)
-	os.WriteFile(filepath.Join(userDir, "private.key"), []byte(clientPriv), 0600)
+	deviceBytes, _ := yaml.Marshal(device)
+	os.WriteFile(filepath.Join(deviceDir, "device.yaml"), deviceBytes, 0644)
+	os.WriteFile(filepath.Join(deviceDir, "private.key"), []byte(clientPriv), 0600)
 
 	// Build client config
 	clientConf := fmt.Sprintf(`[Interface]
@@ -161,7 +170,7 @@ AllowedIPs = %s
 PersistentKeepalive = 25
 `, clientPriv, clientIP, DNSServer, serverPub, serverEndpoint, ListenPort, VPNSubnet)
 
-	os.WriteFile(filepath.Join(userDir, "client.conf"), []byte(clientConf), 0600)
+	os.WriteFile(filepath.Join(deviceDir, "client.conf"), []byte(clientConf), 0600)
 
 	// Add peer to server config
 	if err := m.addPeerToServerConfig(clientPub, clientIP); err != nil {
@@ -171,34 +180,48 @@ PersistentKeepalive = 25
 	return []byte(clientConf), nil
 }
 
-// RevokeClient removes a VPN client.
-func (m *Manager) RevokeClient(userID string) error {
+// RevokeDevice removes a single VPN device.
+// deviceID is "userID/deviceName" (e.g., "admin/laptop").
+func (m *Manager) RevokeDevice(deviceID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	userDir := filepath.Join(m.baseDir, usersDirName, userID)
-	userFile := filepath.Join(userDir, "user.yaml")
+	deviceDir := filepath.Join(m.baseDir, usersDirName, deviceID)
+	deviceFile := filepath.Join(deviceDir, "device.yaml")
 
-	data, err := os.ReadFile(userFile)
+	data, err := os.ReadFile(deviceFile)
 	if err != nil {
-		return fmt.Errorf("user %s not found", userID)
+		return fmt.Errorf("device %s not found", deviceID)
 	}
-	var user VPNUser
-	yaml.Unmarshal(data, &user)
+	var device VPNDevice
+	yaml.Unmarshal(data, &device)
 
 	// Remove peer from server config
-	if err := m.removePeerFromServerConfig(user.PublicKey); err != nil {
+	if err := m.removePeerFromServerConfig(device.PublicKey); err != nil {
 		return err
 	}
 
-	// Delete user directory
-	return os.RemoveAll(userDir)
+	// Delete device directory
+	if err := os.RemoveAll(deviceDir); err != nil {
+		return err
+	}
+
+	// Clean up empty user directory
+	userDir := filepath.Dir(deviceDir)
+	entries, _ := os.ReadDir(userDir)
+	if len(entries) == 0 {
+		os.Remove(userDir)
+	}
+
+	return nil
 }
 
-// ListClients returns all registered VPN users.
-func (m *Manager) ListClients() ([]VPNUser, error) {
+// ListDevices returns all registered VPN devices across all users.
+func (m *Manager) ListDevices() ([]VPNDevice, error) {
 	usersDir := filepath.Join(m.baseDir, usersDirName)
-	entries, err := os.ReadDir(usersDir)
+	var devices []VPNDevice
+
+	userEntries, err := os.ReadDir(usersDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -206,20 +229,29 @@ func (m *Manager) ListClients() ([]VPNUser, error) {
 		return nil, err
 	}
 
-	var users []VPNUser
-	for _, entry := range entries {
-		if !entry.IsDir() {
+	for _, userEntry := range userEntries {
+		if !userEntry.IsDir() {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(usersDir, entry.Name(), "user.yaml"))
+		userPath := filepath.Join(usersDir, userEntry.Name())
+		deviceEntries, err := os.ReadDir(userPath)
 		if err != nil {
 			continue
 		}
-		var user VPNUser
-		yaml.Unmarshal(data, &user)
-		users = append(users, user)
+		for _, devEntry := range deviceEntries {
+			if !devEntry.IsDir() {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(userPath, devEntry.Name(), "device.yaml"))
+			if err != nil {
+				continue
+			}
+			var device VPNDevice
+			yaml.Unmarshal(data, &device)
+			devices = append(devices, device)
+		}
 	}
-	return users, nil
+	return devices, nil
 }
 
 // ServerPublicKey returns the server's public key.
@@ -242,10 +274,10 @@ func (m *Manager) ReloadServer() error {
 // --- internal helpers ---
 
 func (m *Manager) nextAvailableIP() (string, error) {
-	users, _ := m.ListClients()
+	devices, _ := m.ListDevices()
 	used := map[string]bool{ServerIP: true}
-	for _, u := range users {
-		used[u.IP] = true
+	for _, d := range devices {
+		used[d.IP] = true
 	}
 
 	// Assign from 10.8.0.2 to 10.8.0.254

--- a/internal/vpn/wireguard.go
+++ b/internal/vpn/wireguard.go
@@ -1,0 +1,352 @@
+package vpn
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	VPNSubnet    = "10.8.0.0/24"
+	ServerIP     = "10.8.0.1"
+	ListenPort   = 51820
+	DNSServer    = "10.8.0.1"
+	vpnDirName   = "vpn"
+	usersDirName = "users"
+)
+
+// VPNUser represents a registered VPN user.
+type VPNUser struct {
+	ID        string `json:"id" yaml:"id"`
+	PublicKey string `json:"public_key" yaml:"public_key"`
+	IP        string `json:"ip" yaml:"ip"`
+}
+
+// Manager handles WireGuard server and client configuration.
+type Manager struct {
+	baseDir string // ~/.config/bitswan/vpn
+	mu      sync.Mutex
+}
+
+// NewManager creates a VPN manager rooted at the given base dir.
+func NewManager(bitswanConfigDir string) *Manager {
+	return &Manager{
+		baseDir: filepath.Join(bitswanConfigDir, vpnDirName),
+	}
+}
+
+// IsInitialized returns true if the VPN server has been set up.
+func (m *Manager) IsInitialized() bool {
+	_, err := os.Stat(filepath.Join(m.baseDir, "server_private.key"))
+	return err == nil
+}
+
+// Init generates the server keypair and writes wg0.conf.
+func (m *Manager) Init(serverEndpoint string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.IsInitialized() {
+		return fmt.Errorf("VPN already initialized")
+	}
+
+	os.MkdirAll(m.baseDir, 0700)
+	os.MkdirAll(filepath.Join(m.baseDir, usersDirName), 0700)
+
+	// Generate server keypair
+	serverPriv, serverPub, err := generateKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate server keypair: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(m.baseDir, "server_private.key"), []byte(serverPriv), 0600); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(m.baseDir, "server_public.key"), []byte(serverPub), 0644); err != nil {
+		return err
+	}
+
+	// Write initial server config (no peers yet)
+	conf := fmt.Sprintf(`[Interface]
+Address = %s/24
+ListenPort = %d
+PrivateKey = %s
+PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+`, ServerIP, ListenPort, serverPriv)
+
+	if err := os.WriteFile(filepath.Join(m.baseDir, "wg0.conf"), []byte(conf), 0600); err != nil {
+		return err
+	}
+
+	// Store server endpoint for client configs
+	meta := map[string]string{
+		"endpoint":   serverEndpoint,
+		"server_pub": serverPub,
+	}
+	metaBytes, _ := yaml.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(m.baseDir, "meta.yaml"), metaBytes, 0644); err != nil {
+		return err
+	}
+
+	// Write the enabled flag
+	return os.WriteFile(filepath.Join(m.baseDir, "enabled"), []byte("true\n"), 0644)
+}
+
+// GenerateClient creates a new VPN client and returns the client .conf content.
+func (m *Manager) GenerateClient(userID string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.IsInitialized() {
+		return nil, fmt.Errorf("VPN not initialized")
+	}
+
+	userDir := filepath.Join(m.baseDir, usersDirName, userID)
+	if _, err := os.Stat(userDir); err == nil {
+		return nil, fmt.Errorf("user %s already exists", userID)
+	}
+
+	// Read server metadata
+	metaBytes, err := os.ReadFile(filepath.Join(m.baseDir, "meta.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read server metadata: %w", err)
+	}
+	var meta map[string]string
+	yaml.Unmarshal(metaBytes, &meta)
+	serverEndpoint := meta["endpoint"]
+	serverPub := meta["server_pub"]
+
+	// Generate client keypair
+	clientPriv, clientPub, err := generateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate client keypair: %w", err)
+	}
+
+	// Assign next available IP
+	clientIP, err := m.nextAvailableIP()
+	if err != nil {
+		return nil, err
+	}
+
+	// Save client info
+	os.MkdirAll(userDir, 0700)
+	user := VPNUser{
+		ID:        userID,
+		PublicKey: clientPub,
+		IP:        clientIP,
+	}
+	userBytes, _ := yaml.Marshal(user)
+	os.WriteFile(filepath.Join(userDir, "user.yaml"), userBytes, 0644)
+	os.WriteFile(filepath.Join(userDir, "private.key"), []byte(clientPriv), 0600)
+
+	// Build client config
+	clientConf := fmt.Sprintf(`[Interface]
+PrivateKey = %s
+Address = %s/32
+DNS = %s
+
+[Peer]
+PublicKey = %s
+Endpoint = %s:%d
+AllowedIPs = %s
+PersistentKeepalive = 25
+`, clientPriv, clientIP, DNSServer, serverPub, serverEndpoint, ListenPort, VPNSubnet)
+
+	os.WriteFile(filepath.Join(userDir, "client.conf"), []byte(clientConf), 0600)
+
+	// Add peer to server config
+	if err := m.addPeerToServerConfig(clientPub, clientIP); err != nil {
+		return nil, fmt.Errorf("failed to add peer to server: %w", err)
+	}
+
+	return []byte(clientConf), nil
+}
+
+// RevokeClient removes a VPN client.
+func (m *Manager) RevokeClient(userID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	userDir := filepath.Join(m.baseDir, usersDirName, userID)
+	userFile := filepath.Join(userDir, "user.yaml")
+
+	data, err := os.ReadFile(userFile)
+	if err != nil {
+		return fmt.Errorf("user %s not found", userID)
+	}
+	var user VPNUser
+	yaml.Unmarshal(data, &user)
+
+	// Remove peer from server config
+	if err := m.removePeerFromServerConfig(user.PublicKey); err != nil {
+		return err
+	}
+
+	// Delete user directory
+	return os.RemoveAll(userDir)
+}
+
+// ListClients returns all registered VPN users.
+func (m *Manager) ListClients() ([]VPNUser, error) {
+	usersDir := filepath.Join(m.baseDir, usersDirName)
+	entries, err := os.ReadDir(usersDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var users []VPNUser
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(usersDir, entry.Name(), "user.yaml"))
+		if err != nil {
+			continue
+		}
+		var user VPNUser
+		yaml.Unmarshal(data, &user)
+		users = append(users, user)
+	}
+	return users, nil
+}
+
+// ServerPublicKey returns the server's public key.
+func (m *Manager) ServerPublicKey() (string, error) {
+	data, err := os.ReadFile(filepath.Join(m.baseDir, "server_public.key"))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// ReloadServer signals the WireGuard container to reload its config.
+func (m *Manager) ReloadServer() error {
+	// docker exec wireguard wg syncconf wg0 <(wg-quick strip wg0)
+	cmd := exec.Command("docker", "exec", "wireguard", "bash", "-c",
+		"wg syncconf wg0 <(wg-quick strip /config/wg0.conf)")
+	return cmd.Run()
+}
+
+// --- internal helpers ---
+
+func (m *Manager) nextAvailableIP() (string, error) {
+	users, _ := m.ListClients()
+	used := map[string]bool{ServerIP: true}
+	for _, u := range users {
+		used[u.IP] = true
+	}
+
+	// Assign from 10.8.0.2 to 10.8.0.254
+	for i := 2; i < 255; i++ {
+		ip := fmt.Sprintf("10.8.0.%d", i)
+		if !used[ip] {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("no available IP addresses in VPN subnet")
+}
+
+func (m *Manager) addPeerToServerConfig(publicKey, ip string) error {
+	confPath := filepath.Join(m.baseDir, "wg0.conf")
+	f, err := os.OpenFile(confPath, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	peer := fmt.Sprintf("\n[Peer]\nPublicKey = %s\nAllowedIPs = %s/32\n", publicKey, ip)
+	_, err = f.WriteString(peer)
+	if err != nil {
+		return err
+	}
+
+	return m.ReloadServer()
+}
+
+func (m *Manager) removePeerFromServerConfig(publicKey string) error {
+	confPath := filepath.Join(m.baseDir, "wg0.conf")
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var result []string
+	skip := false
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "[Peer]" {
+			skip = false
+		}
+		if skip {
+			continue
+		}
+		if strings.Contains(line, publicKey) {
+			// Remove the [Peer] header we just added
+			if len(result) > 0 && strings.TrimSpace(result[len(result)-1]) == "[Peer]" {
+				result = result[:len(result)-1]
+			}
+			skip = true
+			continue
+		}
+		result = append(result, line)
+	}
+
+	if err := os.WriteFile(confPath, []byte(strings.Join(result, "\n")), 0600); err != nil {
+		return err
+	}
+
+	return m.ReloadServer()
+}
+
+func generateKeyPair() (privateKey, publicKey string, err error) {
+	// Try using wg command if available
+	privCmd := exec.Command("wg", "genkey")
+	privOut, err := privCmd.Output()
+	if err == nil {
+		priv := strings.TrimSpace(string(privOut))
+		pubCmd := exec.Command("wg", "pubkey")
+		pubCmd.Stdin = strings.NewReader(priv)
+		pubOut, err := pubCmd.Output()
+		if err == nil {
+			return priv, strings.TrimSpace(string(pubOut)), nil
+		}
+	}
+
+	// Fallback: generate Curve25519 keypair manually
+	var private [32]byte
+	if _, err := rand.Read(private[:]); err != nil {
+		return "", "", err
+	}
+	// Clamp private key per Curve25519 spec
+	private[0] &= 248
+	private[31] &= 127
+	private[31] |= 64
+
+	priv := base64.StdEncoding.EncodeToString(private[:])
+
+	// Compute public key via Curve25519 scalar multiplication
+	// For simplicity, shell out to wg pubkey if available, otherwise error
+	pubCmd := exec.Command("wg", "pubkey")
+	pubCmd.Stdin = strings.NewReader(priv)
+	pubOut, err := pubCmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("wg command not available for key generation: %w", err)
+	}
+
+	return priv, strings.TrimSpace(string(pubOut)), nil
+}
+
+// Silence unused import warning
+var _ = net.ParseCIDR

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,70 @@
+# Integration Tests
+
+## Network Isolation & VPN Integration Tests
+
+`integration-test.sh` is an end-to-end test suite that verifies:
+
+### Network Isolation (per-stage)
+- Stage networks (`{workspace}-dev`, `-staging`, `-production`) created during workspace init
+- Gitops container on `bitswan_network` only (least privilege)
+- Live-dev automations placed on dev network only
+- Cross-stage DNS isolation (dev cannot resolve staging/production services)
+- Same-stage connectivity (dev containers can reach each other)
+- Management plane isolation (gitops cannot HTTP to automation containers)
+- Selenium isolation (external testing network, no direct access to any stage)
+
+### VPN (WireGuard)
+- VPN init starts WireGuard, VPN Traefik, and CoreDNS containers
+- Bootstrap generates valid WireGuard config with correct endpoint
+- Device management: create, list, revoke individual devices
+- Destroy + reinit lifecycle
+
+## Prerequisites
+
+- A server with Docker installed
+- The `bitswan-automation-server` repo cloned and buildable (Go 1.24+)
+- The `bitswan-gitops` repo cloned (for dev-mode gitops)
+- A DNS wildcard record pointing to the server (e.g., `*.example.bswn.io`)
+
+## Configuration
+
+Edit the top of `integration-test.sh`:
+
+```bash
+DOMAIN="editor-network-test.bswn.io"   # Your test domain
+WORKSPACE="editor-network-test"         # Workspace name
+GITOPS_DEV_SRC="/root/bitswan-gitops"   # Path to gitops repo
+SERVER_IP="88.99.15.208"                # Server public IP
+```
+
+## Running
+
+```bash
+./tests/integration-test.sh
+```
+
+The script:
+1. Tears down any previous test state
+2. Builds the bitswan binary from the current branch
+3. Starts the daemon
+4. Creates a workspace with dev-mode gitops
+5. Deploys a real automation via the gitops API
+6. Runs all isolation tests
+7. Runs VPN lifecycle tests
+8. Tears everything down
+
+## Cron Setup
+
+Run every 30 minutes on a test server:
+
+```bash
+*/30 * * * * /path/to/tests/integration-test.sh >> /var/log/bitswan-integration-tests.log 2>&1
+```
+
+## Output
+
+Results are logged to `/var/log/bitswan-integration-tests.log`:
+
+```
+[2026-04-16T21:30:53Z] Results: 36 passed, 0 failed, 0 skipped, 36 total
+```

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -1,0 +1,452 @@
+#!/bin/bash
+set -uo pipefail
+export PATH=/usr/local/go/bin:$PATH
+
+DOMAIN="editor-network-test.bswn.io"
+WORKSPACE="editor-network-test"
+GITOPS_SECRET=""
+GITOPS_DEV_SRC="/root/bitswan-gitops"
+SERVER_IP="88.99.15.208"
+LOG="/var/log/bitswan-integration-tests.log"
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+RUN_ID="$(date +%s)"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$LOG"; }
+pass() { PASS=$((PASS+1)); TOTAL=$((TOTAL+1)); log "  PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); TOTAL=$((TOTAL+1)); log "  FAIL: $1 — $2"; }
+skip() { SKIP=$((SKIP+1)); TOTAL=$((TOTAL+1)); log "  SKIP: $1"; }
+
+WS_DIR="/root/.config/bitswan/workspaces/${WORKSPACE}/workspace"
+
+# ── SETUP / TEARDOWN ───────────────────────────────────────────────────
+
+teardown() {
+    log "=== TEARDOWN ==="
+    # Stop VPN
+    wg-quick down bitswan-test 2>/dev/null || true
+    rm -f /etc/wireguard/bitswan-test.conf 2>/dev/null || true
+    # Remove workspace containers
+    docker ps -a --format '{{.Names}}' | grep "${WORKSPACE}" | xargs -r docker rm -f 2>/dev/null || true
+    # Remove VPN containers
+    docker rm -f wireguard traefik-vpn coredns-vpn 2>/dev/null || true
+    # Remove workspace dir
+    rm -rf "/root/.config/bitswan/workspaces/${WORKSPACE}" 2>/dev/null || true
+    rm -rf "/root/.config/bitswan/vpn" 2>/dev/null || true
+    rm -rf "/root/.config/bitswan/traefik-vpn" 2>/dev/null || true
+    # Remove networks
+    docker network rm ${WORKSPACE}-dev ${WORKSPACE}-staging ${WORKSPACE}-production \
+        ${WORKSPACE}-external-testing bitswan_vpn_network 2>/dev/null || true
+    log "Teardown complete"
+}
+
+setup() {
+    log "=== SETUP ==="
+    teardown
+
+    log "Building bitswan CLI (combined branch)..."
+    cd /root/bitswan-automation-server
+    git checkout test/combined 2>/dev/null
+    make build 2>&1 | tail -1
+    docker stop bitswan-automation-server-daemon 2>/dev/null || true
+    docker rm -f bitswan-automation-server-daemon 2>/dev/null || true
+    cp -f bitswan /usr/local/bin/bitswan
+
+    log "Updating gitops source..."
+    cd "$GITOPS_DEV_SRC"
+    git checkout feat/stage-networks 2>/dev/null
+    git pull origin feat/stage-networks 2>/dev/null
+
+    log "Initializing daemon..."
+    bitswan automation-server-daemon init 2>&1 | tail -3
+    sleep 5
+
+    log "Creating workspace..."
+    bitswan workspace init --domain "$DOMAIN" \
+        --gitops-dev-source-dir "$GITOPS_DEV_SRC" \
+        --no-ide "$WORKSPACE" 2>&1 | tail -5
+
+    local metadata="/root/.config/bitswan/workspaces/${WORKSPACE}/metadata.yaml"
+    [ ! -f "$metadata" ] && { log "FATAL: metadata.yaml not found"; return 1; }
+    GITOPS_SECRET=$(grep 'gitops-secret' "$metadata" | awk '{print $2}')
+    [ -z "$GITOPS_SECRET" ] && { log "FATAL: No gitops secret"; return 1; }
+
+    # Wait for gitops
+    local gc=$(gc_name)
+    for i in $(seq 1 60); do
+        docker exec "$gc" curl -sf -o /dev/null \
+            -H "Authorization: Bearer $GITOPS_SECRET" \
+            "http://localhost:8079/automations/" 2>/dev/null && break
+        sleep 2
+    done
+    log "Gitops ready. STAGE_NETWORKS=$(docker exec "$gc" printenv BITSWAN_STAGE_NETWORKS 2>/dev/null)"
+
+    # Create test automations
+    mkdir -p "${WS_DIR}/TestBP/test-app"
+    cat > "${WS_DIR}/TestBP/test-app/automation.toml" << 'TOML'
+[deployment]
+image = "nginx:alpine"
+expose = true
+port = 80
+TOML
+
+    # Create worktree
+    docker exec "$gc" curl -sf -X POST "http://localhost:8079/worktrees/create" \
+        -H "Authorization: Bearer $GITOPS_SECRET" \
+        -H "Content-Type: application/json" \
+        -d '{"branch_name": "test-wt"}' 2>/dev/null || true
+    sleep 2
+    mkdir -p "${WS_DIR}/worktrees/test-wt/TestBP/test-app"
+    cp "${WS_DIR}/TestBP/test-app/automation.toml" "${WS_DIR}/worktrees/test-wt/TestBP/test-app/"
+
+    log "Setup complete"
+}
+
+# ── HELPERS ─────────────────────────────────────────────────────────────
+
+gc_name() { docker ps --format '{{.Names}}' | grep "${WORKSPACE}.*gitops" | head -1; }
+
+container_networks() {
+    docker inspect "$1" --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}' 2>/dev/null
+}
+
+container_ip() {
+    docker inspect "$1" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' 2>/dev/null | awk '{print $1}'
+}
+
+can_reach() {
+    docker exec "$1" sh -c "getent hosts $2 2>/dev/null" > /dev/null 2>&1
+}
+
+can_ping() {
+    docker exec "$1" ping -c 1 -W 2 "$2" > /dev/null 2>&1
+}
+
+can_http() {
+    docker exec "$1" sh -c "wget -q -O /dev/null --timeout=3 http://$2 2>/dev/null" > /dev/null 2>&1
+}
+
+wait_container() {
+    local pattern="$1" timeout="${2:-30}"
+    for i in $(seq 1 "$timeout"); do
+        local c=$(docker ps --format '{{.Names}}' | grep "$pattern" | head -1)
+        [ -n "$c" ] && echo "$c" && return 0
+        sleep 2
+    done
+    return 1
+}
+
+deploy_live_dev() {
+    docker exec "$(gc_name)" curl -sf -X POST "http://localhost:8079/automations/start-live-dev" \
+        -H "Authorization: Bearer $GITOPS_SECRET" \
+        -H "Content-Type: application/json" \
+        -d '{"relative_path": "worktrees/test-wt/TestBP/test-app", "worktree": "test-wt"}' 2>&1
+}
+
+# ── NETWORK ISOLATION TESTS ────────────────────────────────────────────
+
+test_stage_networks_created() {
+    log "--- Stage networks created by workspace init ---"
+    for stage in dev staging production; do
+        docker network inspect "${WORKSPACE}-${stage}" > /dev/null 2>&1 && \
+            pass "Network ${WORKSPACE}-${stage} exists" || \
+            fail "Network ${WORKSPACE}-${stage} missing" "workspace init should create it"
+    done
+}
+
+test_gitops_least_privilege() {
+    log "--- Gitops network isolation (least privilege) ---"
+    local gc=$(gc_name)
+    [ -z "$gc" ] && { fail "Gitops not running" ""; return; }
+    local nets=$(container_networks "$gc")
+
+    echo "$nets" | grep -q "bitswan_network" && \
+        pass "Gitops on bitswan_network" || \
+        fail "Gitops not on bitswan_network" "$nets"
+
+    for stage in dev staging production; do
+        echo "$nets" | grep -q "${WORKSPACE}-${stage}" && \
+            fail "Gitops on ${stage} network" "least privilege violated" || \
+            pass "Gitops NOT on ${stage} network"
+    done
+}
+
+test_live_dev_network_placement() {
+    log "--- Live-dev lands on dev network only ---"
+    local result=$(deploy_live_dev)
+    log "  Deploy: ${result:0:120}"
+
+    local container=$(wait_container "test-app.*live-dev" 30) || true
+    if [ -z "$container" ]; then
+        docker logs "$(gc_name)" 2>&1 | grep -i "error\|traceback" | tail -3 | while read l; do log "  gitops: $l"; done
+        fail "Live-dev container not started" "deploy failed"
+        return
+    fi
+    log "  Container: $container"
+    local nets=$(container_networks "$container")
+
+    echo "$nets" | grep -q "${WORKSPACE}-dev" && \
+        pass "Live-dev on dev network" || \
+        fail "Live-dev NOT on dev network" "$nets"
+
+    for net in staging production bitswan_network; do
+        echo "$nets" | grep -q "${WORKSPACE}-${net}\|${net}" && \
+            fail "Live-dev on ${net}" "should be dev only" || \
+            pass "Live-dev NOT on ${net}"
+    done
+}
+
+test_cross_stage_dns_isolation() {
+    log "--- Cross-stage DNS isolation ---"
+    local c=$(docker ps --format '{{.Names}}' | grep "test-app.*live-dev" | head -1)
+    [ -z "$c" ] && { skip "No dev container for DNS test"; return; }
+
+    can_reach "$c" "${WORKSPACE}__postgres-staging" && \
+        fail "Dev resolves staging postgres" "DNS leak" || \
+        pass "Dev cannot resolve staging postgres"
+
+    can_reach "$c" "${WORKSPACE}__postgres" && \
+        fail "Dev resolves production postgres" "DNS leak" || \
+        pass "Dev cannot resolve production postgres"
+
+    can_reach "$c" "${WORKSPACE}-gitops" && \
+        fail "Dev resolves gitops" "management plane leak" || \
+        pass "Dev cannot resolve gitops"
+
+    can_reach "$c" "traefik" && \
+        fail "Dev resolves global traefik" "management plane leak" || \
+        pass "Dev cannot resolve global traefik"
+
+    can_reach "$c" "bitswan-automation-server-daemon" && \
+        fail "Dev resolves daemon" "management plane leak" || \
+        pass "Dev cannot resolve daemon"
+}
+
+test_same_stage_connectivity() {
+    log "--- Same-stage containers can communicate ---"
+    local c=$(docker ps --format '{{.Names}}' | grep "test-app.*live-dev" | head -1)
+    [ -z "$c" ] && { skip "No dev container"; return; }
+
+    docker run -d --name ${WORKSPACE}-dev-peer --network ${WORKSPACE}-dev \
+        --hostname dev-peer alpine sleep 60 > /dev/null 2>&1
+
+    can_reach "$c" "dev-peer" && \
+        pass "Dev app can reach dev-peer (same stage)" || \
+        fail "Dev app cannot reach dev-peer" "same-stage DNS broken"
+
+    docker rm -f ${WORKSPACE}-dev-peer 2>/dev/null || true
+}
+
+test_management_cannot_reach_containers() {
+    log "--- Management plane cannot HTTP to automation containers ---"
+    local gc=$(gc_name)
+    local c=$(docker ps --format '{{.Names}}' | grep "test-app.*live-dev" | head -1)
+    [ -z "$gc" ] || [ -z "$c" ] && { skip "Missing containers"; return; }
+
+    local dev_ip=$(container_ip "$c")
+    [ -z "$dev_ip" ] && { skip "Cannot get dev container IP"; return; }
+
+    can_http "$gc" "${dev_ip}:80" && \
+        fail "Gitops can HTTP to dev container at $dev_ip" "network isolation broken" || \
+        pass "Gitops cannot HTTP to dev container (isolated)"
+}
+
+test_selenium_full_isolation() {
+    log "--- Selenium network isolation ---"
+    docker network create ${WORKSPACE}-external-testing 2>/dev/null || true
+    docker run -d --name ${WORKSPACE}-selenium --network ${WORKSPACE}-external-testing \
+        alpine sleep 60 > /dev/null 2>&1
+
+    local c=$(docker ps --format '{{.Names}}' | grep "test-app.*live-dev" | head -1)
+    if [ -n "$c" ]; then
+        local dev_ip=$(container_ip "$c")
+
+        can_reach "${WORKSPACE}-selenium" "$c" && \
+            fail "Selenium resolves dev by name" "isolation broken" || \
+            pass "Selenium cannot resolve dev container"
+
+        [ -n "$dev_ip" ] && {
+            can_ping "${WORKSPACE}-selenium" "$dev_ip" && \
+                fail "Selenium pings dev IP $dev_ip" "L3 isolation broken" || \
+                pass "Selenium cannot ping dev IP"
+        }
+    fi
+
+    can_ping "${WORKSPACE}-selenium" "8.8.8.8" && \
+        pass "Selenium has internet access" || \
+        fail "Selenium cannot reach internet" "outbound broken"
+
+    # Selenium cannot reach management plane either
+    can_reach "${WORKSPACE}-selenium" "traefik" && \
+        fail "Selenium resolves traefik" "should be fully isolated" || \
+        pass "Selenium cannot resolve traefik"
+
+    docker rm -f ${WORKSPACE}-selenium 2>/dev/null || true
+    docker network rm ${WORKSPACE}-external-testing 2>/dev/null || true
+}
+
+# ── VPN TESTS ──────────────────────────────────────────────────────────
+
+test_vpn_init() {
+    log "--- VPN initialization ---"
+
+    # Init VPN
+    local result
+    result=$(bitswan vpn init --endpoint "$SERVER_IP" 2>&1)
+    log "  vpn init: $(echo "$result" | tail -3 | tr '\n' ' ')"
+
+    # Check containers started
+    docker ps --format '{{.Names}}' | grep -q "wireguard" && \
+        pass "WireGuard container running" || \
+        fail "WireGuard not running" "vpn init failed to start container"
+
+    docker ps --format '{{.Names}}' | grep -q "traefik-vpn" && \
+        pass "VPN Traefik running" || \
+        fail "VPN Traefik not running" "vpn init failed"
+
+    docker ps --format '{{.Names}}' | grep -q "coredns-vpn" && \
+        pass "CoreDNS VPN running" || \
+        fail "CoreDNS VPN not running" "vpn init failed"
+
+    # Check VPN network created
+    docker network inspect bitswan_vpn_network > /dev/null 2>&1 && \
+        pass "bitswan_vpn_network exists" || \
+        fail "bitswan_vpn_network missing" "vpn init should create it"
+}
+
+test_vpn_bootstrap() {
+    log "--- VPN bootstrap (generate admin credentials) ---"
+
+    local result
+    result=$(bitswan vpn bootstrap --device test-device 2>&1)
+    log "  bootstrap: $(echo "$result" | head -1)"
+
+    # Check config file was created
+    local slug=$(grep 'slug' /root/.config/bitswan/automation_server_config.toml 2>/dev/null | awk -F'"' '{print $2}')
+    [ -z "$slug" ] && slug="wireguard"
+    local conf="${slug}.conf"
+
+    [ -f "$conf" ] && \
+        pass "VPN config file created: $conf" || \
+        { fail "VPN config file not created" "expected $conf"; return; }
+
+    # Verify it's valid WireGuard config
+    grep -q "PrivateKey" "$conf" && \
+        pass "Config has PrivateKey" || \
+        fail "Config missing PrivateKey" "invalid wireguard config"
+
+    grep -q "Endpoint = ${SERVER_IP}" "$conf" && \
+        pass "Config has correct endpoint" || \
+        fail "Config has wrong endpoint" "expected $SERVER_IP"
+
+    grep -q "AllowedIPs" "$conf" && \
+        pass "Config has AllowedIPs" || \
+        fail "Config missing AllowedIPs" "invalid config"
+
+    rm -f "$conf" 2>/dev/null
+}
+
+test_vpn_device_management() {
+    log "--- VPN device management ---"
+
+    # List devices
+    local devices
+    devices=$(bitswan vpn list-devices 2>&1)
+    echo "$devices" | grep -q "test-device" && \
+        pass "Device test-device listed" || \
+        fail "Device test-device not in list" "$devices"
+
+    # Generate second device
+    bitswan vpn bootstrap --device second-device 2>/dev/null
+    devices=$(bitswan vpn list-devices 2>&1)
+    echo "$devices" | grep -q "second-device" && \
+        pass "Second device listed" || \
+        fail "Second device not in list" "$devices"
+
+    # Revoke second device
+    bitswan vpn revoke "root/second-device" 2>/dev/null
+    devices=$(bitswan vpn list-devices 2>&1)
+    echo "$devices" | grep -q "second-device" && \
+        fail "Revoked device still listed" "$devices" || \
+        pass "Revoked device removed"
+
+    # First device still exists
+    echo "$devices" | grep -q "test-device" && \
+        pass "First device still exists after revoking second" || \
+        fail "First device disappeared" "$devices"
+
+    # Cleanup conf files
+    rm -f *.conf 2>/dev/null
+}
+
+test_vpn_destroy_and_reinit() {
+    log "--- VPN destroy and reinit ---"
+
+    bitswan vpn destroy 2>/dev/null
+    sleep 2
+
+    docker ps --format '{{.Names}}' | grep -q "wireguard" && \
+        fail "WireGuard still running after destroy" "" || \
+        pass "WireGuard stopped after destroy"
+
+    # Reinit should work
+    bitswan vpn init --endpoint "$SERVER_IP" 2>/dev/null
+    sleep 3
+
+    docker ps --format '{{.Names}}' | grep -q "wireguard" && \
+        pass "WireGuard running after reinit" || \
+        fail "WireGuard not running after reinit" ""
+
+    # Cleanup
+    bitswan vpn destroy 2>/dev/null
+}
+
+# ── MAIN ────────────────────────────────────────────────────────────────
+
+main() {
+    log "========================================================"
+    log "BitSwan Integration Test Suite (run $RUN_ID)"
+    log "$(date -u) | Server: $SERVER_IP | Domain: $DOMAIN"
+    log "========================================================"
+
+    if ! setup; then
+        log "FATAL: Setup failed"
+        teardown
+        exit 1
+    fi
+
+    # Network isolation tests
+    log "== NETWORK ISOLATION =="
+    test_stage_networks_created
+    test_gitops_least_privilege
+    test_live_dev_network_placement
+    test_cross_stage_dns_isolation
+    test_same_stage_connectivity
+    test_management_cannot_reach_containers
+    test_selenium_full_isolation
+
+    # VPN tests
+    log "== VPN =="
+    # Ensure daemon is still running
+    if ! docker ps --format "{{.Names}}" | grep -q bitswan-automation-server-daemon; then
+        log "Restarting daemon for VPN tests..."
+        bitswan automation-server-daemon init 2>&1 | tail -1
+        sleep 5
+    fi
+    test_vpn_init
+    test_vpn_bootstrap
+    test_vpn_device_management
+    test_vpn_destroy_and_reinit
+
+    teardown
+
+    log "========================================================"
+    log "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped, ${TOTAL} total"
+    log "========================================================"
+
+    [ "$FAIL" -gt 0 ] && exit 1 || exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Third PR in the WireGuard VPN series.

- **Magic link system** (`internal/vpn/magiclink.go`): 32-byte random tokens, 1hr expiry, claim tracking
- **External admin page** (OAuth-protected, internet-facing):
  - First-admin bootstrap: download VPN config when no users exist
  - Magic link claim: paste token → authenticate → download config
- **Internal admin page** (VPN-only):
  - User management table with revoke buttons
  - Magic link generation with copy-to-clipboard
  - Active links overview

### Magic Link Flow
1. Admin generates link on internal page → gets claim URL
2. Emails URL to new user
3. User opens URL on external page → authenticates via OAuth → downloads WireGuard config
4. Two-factor security: VPN creds + OAuth for internal apps

## Series
1. Dual-ingress infrastructure (#328)
2. WireGuard server management (#329)
3. **This PR: VPN admin UI and magic links**
4. Route classification in gitops

## Test plan
- [ ] External page shows bootstrap option when no users exist
- [ ] After bootstrap, shows "use magic link" instead
- [ ] Internal page generates magic links
- [ ] Claim URL works and downloads valid WireGuard config

🤖 Generated with [Claude Code](https://claude.com/claude-code)