### PR TITLE
Add per-workspace stage networks for isolation

### DIFF
--- a/internal/daemon/ingress.go
+++ b/internal/daemon/ingress.go
@@ -507,8 +507,13 @@ providers:
 		}
 	}
 
-	// No stage networks — just bitswan_network for backward compatibility
-	traefikDockerCompose, err := dockercompose.CreateWorkspaceTraefikDockerComposeFile(workspaceName, traefikConfigForCompose, domain, nil)
+	// Pass per-workspace stage networks so sub-Traefik can route to containers on each stage network
+	stageNetworks := []string{
+		workspaceName + "-dev",
+		workspaceName + "-staging",
+		workspaceName + "-production",
+	}
+	traefikDockerCompose, err := dockercompose.CreateWorkspaceTraefikDockerComposeFile(workspaceName, traefikConfigForCompose, domain, stageNetworks)
 	if err != nil {
 		return false, fmt.Errorf("failed to create workspace traefik docker-compose file: %w", err)
 	}

--- a/internal/daemon/workspace_init.go
+++ b/internal/daemon/workspace_init.go
@@ -67,6 +67,16 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 	// Init bitswan network
 	docker.EnsureDockerNetwork("bitswan_network", *verbose)
 
+	// Create per-workspace stage networks for isolation
+	stageNetworks := []string{
+		workspaceName + "-dev",
+		workspaceName + "-staging",
+		workspaceName + "-production",
+	}
+	for _, net := range stageNetworks {
+		docker.EnsureDockerNetwork(net, *verbose)
+	}
+
 	var oauthConfig *oauth.Config
 	if *oauthConfigFile != "" {
 		oauthConfig, err = oauth.GetInitOauthConfig(*oauthConfigFile)

--- a/internal/daemon/workspace_remove.go
+++ b/internal/daemon/workspace_remove.go
@@ -145,7 +145,16 @@ func RunWorkspaceRemove(workspaceName string, writer io.Writer) error {
 	}()
 	// Continue immediately - don't wait for ingress cleanup
 
-	// 6. Remove the gitops folder
+	// 6. Remove per-workspace stage networks
+	for _, stage := range []string{"dev", "staging", "production"} {
+		netName := workspaceName + "-" + stage
+		rmCmd := exec.Command("docker", "network", "rm", netName)
+		if err := rmCmd.Run(); err != nil {
+			fmt.Fprintf(writer, "Warning: Failed to remove network %s: %v\n", netName, err)
+		}
+	}
+
+	// 7. Remove the gitops folder
 	workspaceDir := filepath.Join(workspacesFolder, workspaceName)
 	if _, err := os.Stat(workspaceDir); os.IsNotExist(err) {
 		fmt.Fprintf(writer, "Warning: Workspace directory %s does not exist, nothing to remove.\n", workspaceDir)

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -93,6 +93,7 @@ func (config *DockerComposeConfig) CreateDockerComposeFileWithSecret(existingSec
 			"BITSWAN_GITOPS_SECRET=" + gitopsSecretToken,
 			"BITSWAN_GITOPS_DOMAIN=" + config.Domain,
 			"BITSWAN_WORKSPACE_NAME=" + config.WorkspaceName,
+			"BITSWAN_STAGE_NETWORKS=true",
 			"BITSWAN_CERTS_DIR=" + homeDir + "/.config/bitswan/certauthorities",
 		},
 	}


### PR DESCRIPTION
## Summary
First PR in the per-stage network isolation series.

Creates `{workspace}-dev`, `{workspace}-staging`, `{workspace}-production` Docker networks during workspace init. Only the workspace sub-Traefik bridges all three — management services stay on `bitswan_network` only.

- `workspace_init.go`: Create 3 stage networks
- `workspace_remove.go`: Clean up on deletion
- `ingress.go`: Sub-Traefik gets all stage networks
- `dockercompose.go`: Set `BITSWAN_STAGE_NETWORKS=true` env var on gitops

## Isolation model
- Dev automations on `{ws}-dev`, staging on `{ws}-staging`, production on `{ws}-production`
- Coding agent on `bitswan_network` only (least privilege)
- Sub-Traefik is the only multi-homed component

## Test plan
- [ ] `bitswan workspace init test` creates 3 extra networks
- [ ] `docker network ls` shows `test-dev`, `test-staging`, `test-production`
- [ ] `bitswan workspace remove test` removes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)