### PR TITLE
fix: recreate daemon container when config dir is missing

### DIFF
--- a/cmd/automationserverdaemon/init.go
+++ b/cmd/automationserverdaemon/init.go
@@ -94,16 +94,36 @@ func runInitCmd(cmd *cobra.Command, args []string) error {
 		checkRunningCmd := exec.Command("docker", "ps", "--filter", "name=bitswan-automation-server-daemon", "--format", "{{.Names}}")
 		runningOutput, err := checkRunningCmd.Output()
 		if err == nil && len(runningOutput) > 0 {
-			fmt.Println("Automation server daemon is already running")
-			installCompletions()
-			return nil
-		}
-
-		// Container exists but is not running, remove it first
-		fmt.Println("Removing existing stopped container...")
-		removeCmd := exec.Command("docker", "rm", "bitswan-automation-server-daemon")
-		if err := removeCmd.Run(); err != nil {
-			return fmt.Errorf("failed to remove existing container: %w", err)
+			// Container is running — but if ~/.config/bitswan was deleted the bind
+			// mount inside the container will be stale (inode with 0 links) and any
+			// directory creation inside it will fail with ENOENT.  Detect this by
+			// checking whether the host directory still exists; if not, stop and
+			// remove the container so it is re-created with a fresh bind mount below.
+			homeDir, hdErr := config.GetRealUserHomeDir()
+			if hdErr == nil {
+				bitswanConfig := filepath.Join(homeDir, ".config", "bitswan")
+				if _, statErr := os.Stat(bitswanConfig); os.IsNotExist(statErr) {
+					fmt.Println("Detected missing ~/.config/bitswan — recreating daemon container to refresh bind mounts...")
+					exec.Command("docker", "stop", "bitswan-automation-server-daemon").Run()
+					exec.Command("docker", "rm", "bitswan-automation-server-daemon").Run()
+					// Fall through to startDaemonContainer below.
+				} else {
+					fmt.Println("Automation server daemon is already running")
+					installCompletions()
+					return nil
+				}
+			} else {
+				fmt.Println("Automation server daemon is already running")
+				installCompletions()
+				return nil
+			}
+		} else {
+			// Container exists but is not running, remove it first
+			fmt.Println("Removing existing stopped container...")
+			removeCmd := exec.Command("docker", "rm", "bitswan-automation-server-daemon")
+			if err := removeCmd.Run(); err != nil {
+				return fmt.Errorf("failed to remove existing container: %w", err)
+			}
 		}
 	}
 

--- a/internal/daemon/ingress.go
+++ b/internal/daemon/ingress.go
@@ -258,6 +258,9 @@ func initCaddyIngress(verbose bool) (bool, error) {
 		return false, nil
 	}
 
+	if err := os.MkdirAll(bitswanConfig, 0755); err != nil {
+		return false, fmt.Errorf("failed to create bitswan config directory: %w", err)
+	}
 	if err := os.MkdirAll(caddyConfig, 0755); err != nil {
 		return false, fmt.Errorf("failed to create ingress config directory: %w", err)
 	}
@@ -355,6 +358,9 @@ func initTraefikIngress(verbose bool) (bool, error) {
 		exec.Command("docker", "rm", existingId).Run()
 	}
 
+	if err := os.MkdirAll(bitswanConfig, 0755); err != nil {
+		return false, fmt.Errorf("failed to create bitswan config directory: %w", err)
+	}
 	if err := os.MkdirAll(traefikConfig, 0755); err != nil {
 		return false, fmt.Errorf("failed to create ingress config directory: %w", err)
 	}

--- a/internal/daemon/workspace_init.go
+++ b/internal/daemon/workspace_init.go
@@ -58,10 +58,8 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 	bitswanConfig := os.Getenv("HOME") + "/.config/bitswan/"
 	var err error
 
-	if _, err := os.Stat(bitswanConfig); os.IsNotExist(err) {
-		if err := os.MkdirAll(bitswanConfig, 0755); err != nil {
-			return fmt.Errorf("failed to create BitSwan config directory: %w", err)
-		}
+	if err := os.MkdirAll(bitswanConfig, 0755); err != nil {
+		return fmt.Errorf("failed to create BitSwan config directory: %w", err)
 	}
 
 	// Init bitswan network


### PR DESCRIPTION
## Summary

- Recreate the daemon container when `~/.config/bitswan` is missing, rather than assuming it already exists
- Ensure parent config directories are created recursively before initializing ingress subdirectories

## Test plan

- [ ] Remove `~/.config/bitswan` and verify the daemon container is recreated correctly on next run
- [ ] Verify ingress subdirectory initialization succeeds when parent dirs don't yet exist