### PR TITLE
feat: add editor development source directory support

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,6 +21,7 @@ type initOptions struct {
 	gitopsImage        string
 	editorImage        string
 	gitopsDevSourceDir string
+	editorDevSourceDir string
 	oauthConfigFile    string
 	noOauth            bool
 	sshPort            string
@@ -67,6 +68,7 @@ func newInitCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.gitopsImage, "gitops-image", "", "Custom image for the gitops")
 	cmd.Flags().StringVar(&o.editorImage, "editor-image", "", "Custom image for the editor")
 	cmd.Flags().StringVar(&o.gitopsDevSourceDir, "gitops-dev-source-dir", "", "Directory to mount as /src/app in gitops container for development")
+	cmd.Flags().StringVar(&o.editorDevSourceDir, "editor-dev-source-dir", "", "Directory to mount as /opt/bitswan-extension-dev in editor container for development")
 	cmd.Flags().StringVar(&o.oauthConfigFile, "oauth-config", "", "OAuth config file")
 	cmd.Flags().BoolVar(&o.noOauth, "no-oauth", false, "Disable automatically fetching OAuth configuration from AOC")
 	cmd.Flags().StringVar(&o.sshPort, "ssh-port", "", "Use SSH over a custom port with custom SSH config for repositories behind firewalls (e.g., 443, 22)")

--- a/internal/daemon/docs.go
+++ b/internal/daemon/docs.go
@@ -138,7 +138,7 @@ func getOpenAPISpec() string {
 		"### Workspace Create Command\n\n" +
 		"**Topic:** `workspace/create` (subscribe to send commands)\n\n" +
 		"**QoS:** 1\n\n" +
-		"**Request Format:**\n```json\n{\n  \"request-id\": \"unique-request-id\",\n  \"name\": \"workspace-name\",\n  \"remote\": \"git-repo-url\",\n  \"branch\": \"branch-name\",\n  \"domain\": \"example.com\",\n  \"certs-dir\": \"/path/to/certs\",\n  \"verbose\": false,\n  \"mkcerts\": false,\n  \"no-ide\": false,\n  \"set-hosts\": false,\n  \"local\": false,\n  \"gitops-image\": \"image:tag\",\n  \"editor-image\": \"image:tag\",\n  \"gitops-dev-source-dir\": \"/path/to/source\",\n  \"oauth-config\": \"/path/to/oauth.json\",\n  \"no-oauth\": false,\n  \"ssh-port\": \"2222\"\n}\n```\n\n" +
+		"**Request Format:**\n```json\n{\n  \"request-id\": \"unique-request-id\",\n  \"name\": \"workspace-name\",\n  \"remote\": \"git-repo-url\",\n  \"branch\": \"branch-name\",\n  \"domain\": \"example.com\",\n  \"certs-dir\": \"/path/to/certs\",\n  \"verbose\": false,\n  \"mkcerts\": false,\n  \"no-ide\": false,\n  \"set-hosts\": false,\n  \"local\": false,\n  \"gitops-image\": \"image:tag\",\n  \"editor-image\": \"image:tag\",\n  \"gitops-dev-source-dir\": \"/path/to/source\",\n  \"editor-dev-source-dir\": \"/path/to/source\",\n  \"oauth-config\": \"/path/to/oauth.json\",\n  \"no-oauth\": false,\n  \"ssh-port\": \"2222\"\n}\n```\n\n" +
 		"**Response:** Logs and results are published to the `logs` topic (see below).\n\n" +
 		"### Workspace Create Confirm Command\n\n" +
 		"**Topic:** `workspace/create/{request-id}/confirm` (publish to confirm SSH key prompt)\n\n" +

--- a/internal/daemon/mqtt_command_handler.go
+++ b/internal/daemon/mqtt_command_handler.go
@@ -30,6 +30,7 @@ type WorkspaceCreateRequest struct {
 	GitopsImage            string `json:"gitops-image,omitempty"`
 	EditorImage            string `json:"editor-image,omitempty"`
 	GitopsDevSourceDir     string `json:"gitops-dev-source-dir,omitempty"`
+	EditorDevSourceDir     string `json:"editor-dev-source-dir,omitempty"`
 	OauthConfigFile        string `json:"oauth-config,omitempty"`
 	NoOauth                bool   `json:"no-oauth,omitempty"`
 	SshPort                string `json:"ssh-port,omitempty"`
@@ -114,6 +115,9 @@ func (p *MQTTPublisher) handleWorkspaceCreate(client mqtt.Client, msg mqtt.Messa
 	}
 	if req.GitopsDevSourceDir != "" {
 		args = append(args, "--gitops-dev-source-dir", req.GitopsDevSourceDir)
+	}
+	if req.EditorDevSourceDir != "" {
+		args = append(args, "--editor-dev-source-dir", req.EditorDevSourceDir)
 	}
 	if req.OauthConfigFile != "" {
 		args = append(args, "--oauth-config", req.OauthConfigFile)

--- a/internal/daemon/workspace_init.go
+++ b/internal/daemon/workspace_init.go
@@ -41,6 +41,7 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 	gitopsImage := fs.String("gitops-image", "", "")
 	editorImage := fs.String("editor-image", "", "")
 	gitopsDevSourceDir := fs.String("gitops-dev-source-dir", "", "")
+	editorDevSourceDir := fs.String("editor-dev-source-dir", "", "")
 	oauthConfigFile := fs.String("oauth-config", "", "")
 	noOauth := fs.Bool("no-oauth", false, "")
 	sshPort := fs.String("ssh-port", "", "")
@@ -653,7 +654,7 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 	fmt.Println("GitOps deployment set up successfully!")
 
 	// Save metadata to file
-	if err := saveMetadata(gitopsConfig, workspaceName, token, *domain, *noIde, &workspaceId, mqttEnvVars, *gitopsDevSourceDir); err != nil {
+	if err := saveMetadata(gitopsConfig, workspaceName, token, *domain, *noIde, &workspaceId, mqttEnvVars, *gitopsDevSourceDir, *editorDevSourceDir); err != nil {
 		fmt.Printf("Warning: Failed to save metadata: %v\n", err)
 	}
 
@@ -835,7 +836,7 @@ func setHostsFile(workspaceName, domain string, noIde bool) error {
 	return nil
 }
 
-func saveMetadata(gitopsConfig, workspaceName, token, domain string, noIde bool, workspaceId *string, mqttEnvVars []string, gitopsDevSourceDir string) error {
+func saveMetadata(gitopsConfig, workspaceName, token, domain string, noIde bool, workspaceId *string, mqttEnvVars []string, gitopsDevSourceDir, editorDevSourceDir string) error {
 	metadata := config.WorkspaceMetadata{
 		Domain:       domain,
 		GitopsURL:    fmt.Sprintf("https://%s-gitops.%s", workspaceName, domain),
@@ -875,6 +876,11 @@ func saveMetadata(gitopsConfig, workspaceName, token, domain string, noIde bool,
 
 	if gitopsDevSourceDir != "" {
 		metadata.GitopsDevSourceDir = &gitopsDevSourceDir
+	}
+
+	if editorDevSourceDir != "" {
+		metadata.EditorDevSourceDir = &editorDevSourceDir
+		metadata.DevMode = true
 	}
 
 	metadataPath := filepath.Join(gitopsConfig, "metadata.yaml")

--- a/internal/services/editor.go
+++ b/internal/services/editor.go
@@ -232,8 +232,19 @@ func (e *EditorService) Enable(gitopsSecretToken, bitswanEditorImage, domain str
 		mqttEnvVars = append(mqttEnvVars, "OAUTH2_PROXY_MQTT_PASSWORD="+*metadata.MqttPassword)
 	}
 
+	var devConfig *EditorDevConfig
+	if metadata.DevMode {
+		devConfig = &EditorDevConfig{
+			DevMode: true,
+		}
+		if metadata.EditorDevSourceDir != nil {
+			devConfig.EditorDevSourceDir = *metadata.EditorDevSourceDir
+		}
+		fmt.Printf("Dev mode enabled for editor (extension source: %s)\n", devConfig.EditorDevSourceDir)
+	}
+
 	// Generate docker-compose content
-	dockerComposeContent, err := e.CreateDockerCompose(gitopsSecretToken, bitswanEditorImage, domain, oauthConfig, mqttEnvVars, trustCA)
+	dockerComposeContent, err := e.CreateDockerComposeWithDevMode(gitopsSecretToken, bitswanEditorImage, domain, oauthConfig, mqttEnvVars, trustCA, devConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create docker-compose content: %w", err)
 	}


### PR DESCRIPTION
- Introduced `editorDevSourceDir` flag for specifying the source directory for the editor container during development.
- Updated relevant functions and documentation to include the new parameter, ensuring proper handling in workspace initialization and metadata saving.
- Enhanced the editor service to utilize the development source directory when in dev mode.

This change improves the flexibility of the editor setup for development purposes.