### PR TITLE
feat: add support for extra_hosts in Docker Compose configuration

### DIFF
--- a/internal/oauth/config.go
+++ b/internal/oauth/config.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -204,5 +205,31 @@ func CreateOAuthEnvVars(config *Config, serviceName, workspaceName, domain strin
 	}
 
 	return oauthEnvVars
+}
+
+// BuildExtraHosts returns docker-compose `extra_hosts` entries needed for
+// oauth2-proxy's server-side token exchange to reach the OIDC issuer.
+//
+// libc resolves any `*.localhost` name to loopback per RFC 6761, so a
+// container can't reach `https://keycloak.bitswan.localhost/` directly even
+// though the host's Caddy routes it just fine for browser traffic. The
+// `host-gateway` mapping makes the container resolve the public hostname to
+// the host's gateway IP, where Caddy then routes the request to keycloak.
+//
+// Returns nil for non-`.localhost` issuers — real deployments use public DNS
+// and don't need the workaround.
+func BuildExtraHosts(config *Config) []string {
+	if config == nil || config.IssuerUrl == "" {
+		return nil
+	}
+	u, err := url.Parse(config.IssuerUrl)
+	if err != nil {
+		return nil
+	}
+	host := u.Hostname()
+	if host == "" || !strings.HasSuffix(host, ".localhost") {
+		return nil
+	}
+	return []string{host + ":host-gateway"}
 }
 

--- a/internal/services/dashboard.go
+++ b/internal/services/dashboard.go
@@ -89,18 +89,22 @@ func (d *DashboardService) CreateDockerComposeWithDevMode(gitopsSecretToken, bit
 			// written by the coding-agent wrapper, for the dashboard's
 			// session list + asciinema playback.
 			gitopsPath + "/coding-agent-sessions:/workspace/agent-sessions:ro",
-			// Claude's per-project JSONL conversation history. The agent
-			// writes here as user `agent` (its $HOME is the coding-agent-home
-			// volume); the dashboard reads it to extract human-readable
-			// session titles (first user prompt) without round-tripping
-			// through the agent container.
-			gitopsPath + "/coding-agent-home/.claude:/workspace/.claude:ro",
+			// Read-only view of the coding-agent's $HOME so the dashboard can
+			// resolve per-user Claude transcripts (`.claude_<slug>/projects/...`)
+			// as well as the legacy shared `.claude/projects/...` for session
+			// titles. Mounting the whole home rather than just `.claude` lets
+			// the dashboard see every user's config dir without us hard-coding
+			// the slug set.
+			gitopsPath + "/coding-agent-home:/workspace/agent-home:ro",
 		},
 	}
 
 	if oauthConfig != nil {
 		dashboardOAuthEnvVars := oauth.CreateOAuthEnvVars(oauthConfig, "dashboard", workspaceName, domain)
 		bitswanDashboard["environment"] = append(bitswanDashboard["environment"].([]string), dashboardOAuthEnvVars...)
+		if extraHosts := oauth.BuildExtraHosts(oauthConfig); len(extraHosts) > 0 {
+			bitswanDashboard["extra_hosts"] = extraHosts
+		}
 	}
 
 	if len(mqttEnvVars) > 0 {

--- a/internal/services/editor.go
+++ b/internal/services/editor.go
@@ -101,6 +101,9 @@ func (e *EditorService) CreateDockerComposeWithDevMode(gitopsSecretToken, bitswa
 	if oauthConfig != nil {
 		oauthEnvVars := oauth.CreateOAuthEnvVars(oauthConfig, "editor", workspaceName, domain)
 		bitswanEditor["environment"] = append(bitswanEditor["environment"].([]string), oauthEnvVars...)
+		if extraHosts := oauth.BuildExtraHosts(oauthConfig); len(extraHosts) > 0 {
+			bitswanEditor["extra_hosts"] = extraHosts
+		}
 	}
 
 	// Append MQTT env variables when workspace is connected to AOC


### PR DESCRIPTION
- Introduced a new function, BuildExtraHosts, to generate `extra_hosts` entries for oauth2-proxy's server-side token exchange, addressing issues with resolving `.localhost` domains in Docker containers.
- Updated the CreateDockerComposeWithDevMode function in both the dashboard and editor services to include the generated `extra_hosts` when applicable.
- Also changes mount for coding agent (related to per-user logins PR) 

This change enhances the Docker Compose setup for OAuth services, improving connectivity to OIDC issuers in local development environments.