### PR TITLE
Move coding agent deploy to automation server and enhance workspace removal process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,14 +134,14 @@ jobs:
           ./bitswan automation-server-daemon status || exit 1
 
       - name: "Test 1: Init with Traefik (default)"
-        timeout-minutes: 20
+        timeout-minutes: 15
         run: |
           echo "=== Testing with Traefik (default ingress) ==="
           ./bitswan _test init --gitops-image bitswan/gitops-local:latest --no-remove || exit 1
           ./bitswan _test cleanup || true
 
       - name: "Test 2: Init with Caddy (backward compat)"
-        timeout-minutes: 20
+        timeout-minutes: 15
         run: |
           echo "=== Testing with Caddy (backward compatibility) ==="
           # Rebuild gitops image (previous test cleanup deletes it)
@@ -159,7 +159,7 @@ jobs:
           ./bitswan _test cleanup || true
 
       - name: "Test 3: Migrate Caddy to Traefik and re-test"
-        timeout-minutes: 20
+        timeout-minutes: 15
         run: |
           echo "=== Testing migration from Caddy to Traefik ==="
           # Rebuild gitops image (previous test cleanup deletes it)

--- a/cmd/service/coding_agent.go
+++ b/cmd/service/coding_agent.go
@@ -37,6 +37,7 @@ func newCodingAgentEnableCmd() *cobra.Command {
 	var workspace string
 	var devMode bool
 	var sourceDir string
+	var staging bool
 
 	cmd := &cobra.Command{
 		Use:   "enable",
@@ -61,6 +62,9 @@ func newCodingAgentEnableCmd() *cobra.Command {
 			options := make(map[string]interface{})
 			if codingAgentImage != "" {
 				options["coding_agent_image"] = codingAgentImage
+			}
+			if staging {
+				options["staging"] = true
 			}
 
 			if devMode {
@@ -90,6 +94,7 @@ func newCodingAgentEnableCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&devMode, "dev-mode", false, "Mount source files from bitswan-agent for live development")
 	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "Path to bitswan-agent source (default: workspace/AOC/bitswan-agent)")
 	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Workspace name (uses active workspace if not specified)")
+	cmd.Flags().BoolVar(&staging, "staging", false, "Use the staging coding-agent image")
 
 	return cmd
 }
@@ -270,6 +275,7 @@ func newCodingAgentStopCmd() *cobra.Command {
 func newCodingAgentUpdateCmd() *cobra.Command {
 	var codingAgentImage string
 	var workspace string
+	var staging bool
 
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -295,6 +301,9 @@ func newCodingAgentUpdateCmd() *cobra.Command {
 			if codingAgentImage != "" {
 				options["coding_agent_image"] = codingAgentImage
 			}
+			if staging {
+				options["staging"] = true
+			}
 
 			result, err := client.UpdateService("coding-agent", workspace, options)
 			if err != nil {
@@ -309,6 +318,7 @@ func newCodingAgentUpdateCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&codingAgentImage, "coding-agent-image", "", "Custom image for the coding agent")
 	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Workspace name (uses active workspace if not specified)")
+	cmd.Flags().BoolVar(&staging, "staging", false, "Update to the latest staging coding-agent image")
 
 	return cmd
 }

--- a/cmd/test/init.go
+++ b/cmd/test/init.go
@@ -78,7 +78,7 @@ func runTestInit(noRemove bool, gitopsImage, editorImage string) error {
 	fmt.Printf("Test workspace name: %s\n", workspaceName)
 
 	// Step 1: Initialize workspace
-	fmt.Println("\n[1/8] Initializing workspace...")
+	fmt.Println("\n[1/6] Initializing workspace...")
 	client, err := daemon.NewClient()
 	if err != nil {
 		return fmt.Errorf("failed to create daemon client: %w", err)
@@ -89,6 +89,7 @@ func runTestInit(noRemove bool, gitopsImage, editorImage string) error {
 		"workspace", "init",
 		"--local",
 		"--no-ide",
+		"--no-dashboard",
 		"--no-oauth",
 	}
 	if gitopsImage != "" {
@@ -110,67 +111,51 @@ func runTestInit(noRemove bool, gitopsImage, editorImage string) error {
 		return fmt.Errorf("failed to get workspace metadata: %w", err)
 	}
 
-	// Wait for gitops service to be ready
-	fmt.Println("\n[1.5/7] Waiting for gitops service to be ready...")
+	// Step 2: Wait for gitops service to be ready
+	fmt.Println("\n[2/6] Waiting for gitops service to be ready...")
 	if err := waitForGitopsReady(metadata.GitopsURL, metadata.GitopsSecret, workspaceName); err != nil {
 		cleanupWorkspace(workspaceName)
 		return fmt.Errorf("gitops service did not become ready: %w", err)
 	}
 	fmt.Println("✓ Gitops service ready")
 
-	// Step 2: Create ZIP from FastAPI example and calculate checksum
-	// First, compute the image directory hash so we can write a correct automation.toml
-	// into the ZIP. The upstream example may have a stale image tag in automation.toml
-	// if the image/ directory contents changed without updating the config.
-	fmt.Println("\n[2/8] Creating ZIP from FastAPI example...")
-	imageHash, err := computeImageDirHash()
-	if err != nil {
-		fmt.Printf("Note: Could not compute image hash (image dir may not exist): %v\n", err)
-	}
-	zipPath, checksum, err := createFastAPIZip(imageHash)
-	if err != nil {
-		cleanupWorkspace(workspaceName)
-		return fmt.Errorf("failed to create ZIP: %w", err)
-	}
-	defer os.Remove(zipPath)
-	fmt.Printf("✓ ZIP created: %s (checksum: %s)\n", zipPath, checksum)
-
-	// Step 3: Upload asset
-	fmt.Println("\n[3/8] Uploading asset to gitops...")
-	if err := uploadAsset(metadata.GitopsURL, metadata.GitopsSecret, workspaceName, zipPath, checksum); err != nil {
-		cleanupWorkspace(workspaceName)
-		return fmt.Errorf("failed to upload asset: %w", err)
-	}
-	fmt.Println("✓ Asset uploaded")
-
-	// Step 3.5: Build image if needed
-	fmt.Println("\n[3.5/8] Building automation image...")
-	deploymentID := "test-fastapi"
-	// Extract image name from automation.toml - it expects "fastapi" not "test-fastapi"
-	imageName := "fastapi"
-	imageTag, err := buildAutomationImage(metadata.GitopsURL, metadata.GitopsSecret, workspaceName, imageName, checksum)
+	// Step 3: Scaffold the FastAPI automation from the built-in template gallery.
+	// The examples tree is bind-mounted read-only into the gitops container at
+	// /workspace/examples; gitops copies the chosen template into the workspace
+	// repo (/workspace-repo) under <bp>/<name> and commits it. This replaces the
+	// old upload-asset flow — gitops is now the sole writer to the workspace repo.
+	fmt.Println("\n[3/6] Creating FastAPI automation from template...")
+	const (
+		templateID = "FastAPIApp"
+		bp         = "test"
+		automation = "fastapi"
+	)
+	relativePath, err := createAutomationFromTemplate(metadata.GitopsURL, metadata.GitopsSecret, workspaceName, templateID, bp, automation)
 	if err != nil {
 		cleanupWorkspace(workspaceName)
-		return fmt.Errorf("failed to build image: %w", err)
+		return fmt.Errorf("failed to create automation from template: %w", err)
 	}
-	if imageTag != "" {
-		fmt.Printf("✓ Image built: %s\n", imageTag)
-	} else {
-		fmt.Println("✓ Image already exists or not needed")
-	}
+	fmt.Printf("✓ Automation created at: %s\n", relativePath)
 
-	// Step 4: Deploy automation
-	fmt.Println("\n[4/8] Deploying automation...")
-	if err := deployAutomation(metadata.GitopsURL, metadata.GitopsSecret, workspaceName, deploymentID, checksum); err != nil {
+	// Step 4: Deploy the automation directly from the workspace. gitops reads the
+	// source from /workspace-repo, builds the per-automation image from its image/
+	// Dockerfile, materializes the merged tree, and runs the deploy pipeline. No
+	// client-side ZIP/image build/upload is required anymore.
+	fmt.Println("\n[4/6] Deploying automation...")
+	taskID, deploymentID, _, err := startDeploy(metadata.GitopsURL, metadata.GitopsSecret, workspaceName, relativePath, "dev")
+	if err != nil {
 		cleanupWorkspace(workspaceName)
-		return fmt.Errorf("failed to deploy automation: %w", err)
+		return fmt.Errorf("failed to start deploy: %w", err)
+	}
+	fmt.Printf("  Deploy started: task=%s deployment=%s\n", taskID, deploymentID)
+	if err := waitForDeployTask(metadata.GitopsURL, metadata.GitopsSecret, workspaceName, taskID); err != nil {
+		cleanupWorkspace(workspaceName)
+		return fmt.Errorf("deploy did not complete: %w", err)
 	}
 	fmt.Println("✓ Automation deployed")
-	// Give deployment a moment to start
-	time.Sleep(5 * time.Second)
 
-	// Step 5: Wait for deployment and test endpoint
-	fmt.Println("\n[5/8] Waiting for deployment to be ready...")
+	// Step 5: Wait for the deployment to be running and test the endpoint
+	fmt.Println("\n[5/6] Waiting for deployment to be ready...")
 	endpointURL, err := waitForDeployment(metadata.GitopsURL, metadata.GitopsSecret, workspaceName, deploymentID)
 	if err != nil {
 		cleanupWorkspace(workspaceName)
@@ -182,7 +167,7 @@ func runTestInit(noRemove bool, gitopsImage, editorImage string) error {
 	}
 	fmt.Printf("✓ Deployment ready at: %s\n", endpointURL)
 
-	fmt.Println("\n[6/8] Testing endpoint...")
+	fmt.Println("\nTesting endpoint...")
 	if err := testEndpoint(endpointURL, workspaceName); err != nil {
 		if !noRemove {
 			cleanupWorkspace(workspaceName)
@@ -192,22 +177,21 @@ func runTestInit(noRemove bool, gitopsImage, editorImage string) error {
 	fmt.Println("✓ Endpoint test passed")
 
 	if noRemove {
-		fmt.Println("\n[7/8] Skipping cleanup (--no-remove flag set)...")
+		fmt.Println("\n[6/6] Skipping cleanup (--no-remove flag set)...")
 		fmt.Printf("Workspace '%s' is still running\n", workspaceName)
 		fmt.Printf("Endpoint: %s\n", endpointURL)
 		fmt.Println("\n=== Test Suite: SUCCESS (workspace left running) ===")
 		return nil
 	}
 
-	// Step 6: Remove deployment
-	fmt.Println("\n[7/8] Cleaning up...")
+	// Step 6: Remove deployment and workspace
+	fmt.Println("\n[6/6] Cleaning up...")
 	if err := removeAutomation(metadata.GitopsURL, metadata.GitopsSecret, workspaceName, deploymentID); err != nil {
 		fmt.Printf("Warning: Failed to remove automation: %v\n", err)
 	} else {
 		fmt.Println("✓ Automation removed")
 	}
 
-	// Step 7: Remove workspace
 	if err := cleanupWorkspace(workspaceName); err != nil {
 		return fmt.Errorf("failed to cleanup workspace: %w", err)
 	}
@@ -215,6 +199,166 @@ func runTestInit(noRemove bool, gitopsImage, editorImage string) error {
 
 	fmt.Println("\n=== Test Suite: SUCCESS ===")
 	return nil
+}
+
+// createAutomationFromTemplate scaffolds an automation from a built-in template
+// (e.g. "FastAPIApp") into the workspace repo via gitops' POST
+// /automations/from-template endpoint. gitops copies the template — sourced from
+// the read-only examples tree mounted at /workspace/examples — into
+// /workspace-repo/<bp>/<name>, injects a deployment id, and commits it. Returns
+// the workspace-relative path of the created automation (e.g. "test/fastapi").
+func createAutomationFromTemplate(gitopsURL, secret, workspaceName, templateID, bp, name string) (string, error) {
+	payload := map[string]string{
+		"template_id": templateID,
+		"bp":          bp,
+		"name":        name,
+	}
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	url := fmt.Sprintf("%s/automations/from-template", gitopsURL)
+	url = automations.TransformURLForDaemon(url, workspaceName)
+	req, err := httpReq.NewRequest("POST", url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+secret)
+
+	resp, err := httpReq.ExecuteRequestWithLocalhostResolution(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	respBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("from-template failed with status %d: %s", resp.StatusCode, string(respBytes))
+	}
+
+	var result struct {
+		Created []struct {
+			Name         string `json:"name"`
+			RelativePath string `json:"relative_path"`
+		} `json:"created"`
+	}
+	if err := json.Unmarshal(respBytes, &result); err != nil {
+		return "", fmt.Errorf("failed to parse from-template response: %w (body: %s)", err, string(respBytes))
+	}
+	if len(result.Created) == 0 {
+		return "", fmt.Errorf("from-template created no automations (body: %s)", string(respBytes))
+	}
+	return result.Created[0].RelativePath, nil
+}
+
+// startDeploy kicks off a deploy of a workspace-resident automation via gitops'
+// POST /automations/start-deploy endpoint. gitops reads the source from
+// /workspace-repo, builds the image (if the automation ships an image/Dockerfile),
+// computes the merged-tree checksum, and runs the deploy pipeline in the
+// background. The endpoint returns 202 immediately; use waitForDeployTask to
+// block until the background pipeline finishes. Returns the task id, deployment
+// id, and the (possibly empty) exposed URL gitops constructed.
+func startDeploy(gitopsURL, secret, workspaceName, relativePath, stage string) (taskID, deploymentID, url string, err error) {
+	payload := map[string]interface{}{
+		"relative_path": relativePath,
+		"stage":         stage,
+	}
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	reqURL := fmt.Sprintf("%s/automations/start-deploy", gitopsURL)
+	reqURL = automations.TransformURLForDaemon(reqURL, workspaceName)
+	req, err := httpReq.NewRequest("POST", reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", "", "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+secret)
+
+	resp, err := httpReq.ExecuteRequestWithLocalhostResolution(req)
+	if err != nil {
+		return "", "", "", err
+	}
+	defer resp.Body.Close()
+
+	respBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return "", "", "", fmt.Errorf("start-deploy failed with status %d: %s", resp.StatusCode, string(respBytes))
+	}
+
+	var result struct {
+		TaskID       string `json:"task_id"`
+		DeploymentID string `json:"deployment_id"`
+		Checksum     string `json:"checksum"`
+		URL          string `json:"url"`
+		Status       string `json:"status"`
+	}
+	if err := json.Unmarshal(respBytes, &result); err != nil {
+		return "", "", "", fmt.Errorf("failed to parse start-deploy response: %w (body: %s)", err, string(respBytes))
+	}
+	return result.TaskID, result.DeploymentID, result.URL, nil
+}
+
+// waitForDeployTask polls gitops' GET /automations/deploy-status/{task_id}
+// endpoint until the background deploy pipeline reaches a terminal state.
+// Returns nil on "completed" and an error (carrying the server-side detail) on
+// "failed" or timeout. Image builds in CI can be slow, so the deadline is
+// generous (20 minutes).
+func waitForDeployTask(gitopsURL, secret, workspaceName, taskID string) error {
+	maxAttempts := 600 // 20 minutes (600 * 2 seconds)
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		reqURL := fmt.Sprintf("%s/automations/deploy-status/%s", gitopsURL, taskID)
+		reqURL = automations.TransformURLForDaemon(reqURL, workspaceName)
+		req, err := httpReq.NewRequest("GET", reqURL, nil)
+		if err != nil {
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		req.Header.Set("Authorization", "Bearer "+secret)
+
+		resp, err := httpReq.ExecuteRequestWithLocalhostResolution(req)
+		if err != nil {
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			var task struct {
+				Status  string `json:"status"`
+				Step    string `json:"step"`
+				Message string `json:"message"`
+				Error   string `json:"error"`
+			}
+			if err := json.Unmarshal(bodyBytes, &task); err == nil {
+				switch task.Status {
+				case "completed":
+					return nil
+				case "failed":
+					if task.Error != "" {
+						return fmt.Errorf("deploy task failed: %s", task.Error)
+					}
+					return fmt.Errorf("deploy task failed: %s", task.Message)
+				default:
+					if attempt%10 == 0 {
+						fmt.Printf("  Deploy in progress (status=%s, step=%s): %s (attempt %d/%d)\n", task.Status, task.Step, task.Message, attempt+1, maxAttempts)
+					}
+				}
+			}
+		} else if attempt%30 == 0 {
+			fmt.Printf("  deploy-status returned %d (attempt %d/%d): %s\n", resp.StatusCode, attempt+1, maxAttempts, string(bodyBytes))
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+
+	return fmt.Errorf("deploy task did not complete within timeout")
 }
 
 // computeImageDirHash calculates the git tree hash of the FastAPI image/ directory.
@@ -233,6 +377,10 @@ func computeImageDirHash() (string, error) {
 	return calculateGitTreeHash(imageDir)
 }
 
+// NOTE: No longer used by the init test, which now deploys via the
+// workspace-mounted flow (createAutomationFromTemplate + startDeploy). Retained
+// only for the legacy pull-and-deploy test, which still targets gitops' removed
+// upload endpoints and is pending migration (see TODO in pull_and_deploy.go).
 func createFastAPIZip(imageHash string) (string, string, error) {
 	// Find the FastAPI example directory in bitswan-src
 	homeDir := os.Getenv("HOME")
@@ -358,6 +506,10 @@ func createFastAPIZip(imageHash string) (string, string, error) {
 	return zipPath, checksum, nil
 }
 
+// NOTE: No longer used by the init test. The workspace-mounted deploy flow lets
+// gitops compute checksums itself, so this is retained only for the legacy
+// pull-and-deploy test, which is pending migration (see TODO in pull_and_deploy.go).
+//
 // calculateGitTreeHash calculates the git tree hash of a directory
 // This implements git's tree object format
 func calculateGitTreeHash(dirPath string) (string, error) {
@@ -365,51 +517,51 @@ func calculateGitTreeHash(dirPath string) (string, error) {
 	if gitPath, err := exec.LookPath("git"); err == nil {
 		cmd := exec.Command(gitPath, "hash-object", "-t", "tree", "--stdin")
 		cmd.Dir = dirPath
-		
+
 		// Create a temporary git index
 		tmpDir, err := os.MkdirTemp("", "git-tree-hash-*")
 		if err != nil {
 			return "", err
 		}
 		defer os.RemoveAll(tmpDir)
-		
+
 		// Copy directory to temp location and use git
 		// Actually, let's use a simpler approach: use git hash-object on the directory
 		// But git hash-object doesn't work on directories directly
 		// So we need to implement it ourselves or use git write-tree
-		
+
 		// For now, let's implement a basic version
 	}
-	
+
 	// Implement git tree hash calculation
 	return calculateGitTreeHashRecursive(dirPath)
 }
 
 func calculateGitTreeHashRecursive(dirPath string) (string, error) {
 	type entry struct {
-		mode string
-		name string
-		hash string
+		mode  string
+		name  string
+		hash  string
 		isDir bool
 	}
-	
+
 	var entries []entry
-	
+
 	// Read directory
 	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		return "", err
 	}
-	
+
 	// Process each file/directory
 	for _, file := range files {
 		// Skip .git and hidden files
 		if strings.HasPrefix(file.Name(), ".") {
 			continue
 		}
-		
+
 		filePath := filepath.Join(dirPath, file.Name())
-		
+
 		if file.IsDir() {
 			// Recursively calculate tree hash for subdirectory
 			subHash, err := calculateGitTreeHashRecursive(filePath)
@@ -417,9 +569,9 @@ func calculateGitTreeHashRecursive(dirPath string) (string, error) {
 				return "", err
 			}
 			entries = append(entries, entry{
-				mode: "040000",
-				name: file.Name(),
-				hash: subHash,
+				mode:  "040000",
+				name:  file.Name(),
+				hash:  subHash,
 				isDir: true,
 			})
 		} else {
@@ -428,7 +580,7 @@ func calculateGitTreeHashRecursive(dirPath string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			
+
 			// Determine file mode (executable or regular)
 			info, err := os.Stat(filePath)
 			if err != nil {
@@ -438,16 +590,16 @@ func calculateGitTreeHashRecursive(dirPath string) (string, error) {
 			if info.Mode().Perm()&0111 != 0 {
 				mode = "100755" // executable
 			}
-			
+
 			entries = append(entries, entry{
-				mode: mode,
-				name: file.Name(),
-				hash: blobHash,
+				mode:  mode,
+				name:  file.Name(),
+				hash:  blobHash,
 				isDir: false,
 			})
 		}
 	}
-	
+
 	// Sort entries: directories first, then alphabetically
 	sort.Slice(entries, func(i, j int) bool {
 		if entries[i].isDir != entries[j].isDir {
@@ -455,7 +607,7 @@ func calculateGitTreeHashRecursive(dirPath string) (string, error) {
 		}
 		return entries[i].name < entries[j].name
 	})
-	
+
 	// Build tree object: "tree <size>\0<entries>"
 	var treeContent []byte
 	for _, e := range entries {
@@ -464,40 +616,43 @@ func calculateGitTreeHashRecursive(dirPath string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("invalid hash: %w", err)
 		}
-		
+
 		entryStr := fmt.Sprintf("%s %s\000", e.mode, e.name)
 		treeContent = append(treeContent, []byte(entryStr)...)
 		treeContent = append(treeContent, hashBytes...)
 	}
-	
+
 	// Create tree header: "tree <size>\0"
 	treeHeader := fmt.Sprintf("tree %d\000", len(treeContent))
 	treeObject := append([]byte(treeHeader), treeContent...)
-	
+
 	// Calculate SHA1 hash
 	hasher := sha1.New()
 	hasher.Write(treeObject)
 	hash := hex.EncodeToString(hasher.Sum(nil))
-	
+
 	return hash, nil
 }
 
+// NOTE: No longer used by the init test; only reached via calculateGitTreeHash
+// from the legacy pull-and-deploy test (pending migration — see TODO in
+// pull_and_deploy.go).
 func calculateGitBlobHash(filePath string) (string, error) {
 	// Read file content
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", err
 	}
-	
+
 	// Create blob: "blob <size>\0<content>"
 	blobHeader := fmt.Sprintf("blob %d\000", len(content))
 	blob := append([]byte(blobHeader), content...)
-	
+
 	// Calculate SHA1 hash
 	hasher := sha1.New()
 	hasher.Write(blob)
 	hash := hex.EncodeToString(hasher.Sum(nil))
-	
+
 	return hash, nil
 }
 
@@ -549,7 +704,7 @@ func waitForGitopsReady(gitopsURL, secret, workspaceName string) error {
 					// Use docker exec to curl from within the network
 					if attempt > 30 { // After 60 seconds, try direct connection
 						// Try to curl from within the container's network
-						curlCmd := exec.Command("docker", "exec", containerName, "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", 
+						curlCmd := exec.Command("docker", "exec", containerName, "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
 							"-H", fmt.Sprintf("Authorization: Bearer %s", secret),
 							"http://localhost:8079/automations")
 						if curlOutput, curlErr := curlCmd.Output(); curlErr == nil {
@@ -600,7 +755,7 @@ func waitForGitopsReady(gitopsURL, secret, workspaceName string) error {
 				// After many attempts, check if service is actually running but Caddy can't reach it
 				if attempt > 60 {
 					// Try direct connection to container
-					curlCmd := exec.Command("docker", "exec", containerName, "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", 
+					curlCmd := exec.Command("docker", "exec", containerName, "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
 						"-H", fmt.Sprintf("Authorization: Bearer %s", secret),
 						"http://localhost:8079/automations")
 					if curlOutput, curlErr := curlCmd.Output(); curlErr == nil {
@@ -695,9 +850,9 @@ func buildAutomationImage(gitopsURL, secret, workspaceName, imageName, checksum 
 	if homeDir == "" {
 		return "", fmt.Errorf("HOME environment variable not set")
 	}
-	
+
 	fastAPIDir := filepath.Join(homeDir, ".config", "bitswan", "bitswan-src", "examples", "FastAPIApp")
-	
+
 	// Check if directory exists
 	if _, err := os.Stat(fastAPIDir); os.IsNotExist(err) {
 		return "", fmt.Errorf("FastAPI example directory not found at %s. Ensure workspace init has created bitswan-src", fastAPIDir)
@@ -981,12 +1136,12 @@ func waitForDeployment(gitopsURL, secret, workspaceName, deploymentID string) (s
 		// Use /automations/ with trailing slash to avoid 307 redirect that loses Authorization header
 		reqURL := fmt.Sprintf("%s/automations/", gitopsURL)
 		reqURL = automations.TransformURLForDaemon(reqURL, workspaceName)
-		
+
 		// Log the request details
 		if attempt%5 == 0 || attempt < 3 {
 			fmt.Printf("  [Attempt %d/%d] GET %s\n", attempt+1, maxAttempts, reqURL)
 		}
-		
+
 		req, err := httpReq.NewRequest("GET", reqURL, nil)
 		if err != nil {
 			if attempt%5 == 0 || attempt < 3 {
@@ -1097,17 +1252,17 @@ func waitForDeployment(gitopsURL, secret, workspaceName, deploymentID string) (s
 						fmt.Printf("  Automation '%s' not found in list (attempt %d/%d, found %d automations)\n", deploymentID, attempt+1, maxAttempts, len(automations))
 					}
 				}
-				} else {
-					// Log parse errors more frequently
-					if attempt%10 == 0 {
-						fmt.Printf("  Failed to parse automations response (attempt %d/%d): %v\n", attempt+1, maxAttempts, err)
-						bodyPreview := string(bodyBytes)
-						if len(bodyPreview) > 500 {
-							bodyPreview = bodyPreview[:500]
-						}
-						fmt.Printf("  Response body (first 500 chars): %s\n", bodyPreview)
+			} else {
+				// Log parse errors more frequently
+				if attempt%10 == 0 {
+					fmt.Printf("  Failed to parse automations response (attempt %d/%d): %v\n", attempt+1, maxAttempts, err)
+					bodyPreview := string(bodyBytes)
+					if len(bodyPreview) > 500 {
+						bodyPreview = bodyPreview[:500]
 					}
+					fmt.Printf("  Response body (first 500 chars): %s\n", bodyPreview)
 				}
+			}
 		} else {
 			// Log non-200 responses
 			bodyBytes, _ := io.ReadAll(resp.Body)
@@ -1194,4 +1349,3 @@ func cleanupWorkspace(workspaceName string) error {
 
 	return client.WorkspaceRemove(workspaceName)
 }
-

--- a/cmd/test/init.go
+++ b/cmd/test/init.go
@@ -306,10 +306,11 @@ func startDeploy(gitopsURL, secret, workspaceName, relativePath, stage string) (
 // waitForDeployTask polls gitops' GET /automations/deploy-status/{task_id}
 // endpoint until the background deploy pipeline reaches a terminal state.
 // Returns nil on "completed" and an error (carrying the server-side detail) on
-// "failed" or timeout. Image builds in CI can be slow, so the deadline is
-// generous (20 minutes).
+// "failed" or timeout. This only covers the background deploy pipeline (compose
+// up, cert install, oauth proxy) — the image build already ran synchronously
+// inside the start-deploy call — so a few minutes is plenty.
 func waitForDeployTask(gitopsURL, secret, workspaceName, taskID string) error {
-	maxAttempts := 600 // 20 minutes (600 * 2 seconds)
+	maxAttempts := 150 // 5 minutes (150 * 2 seconds)
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		reqURL := fmt.Sprintf("%s/automations/deploy-status/%s", gitopsURL, taskID)
@@ -657,8 +658,9 @@ func calculateGitBlobHash(filePath string) (string, error) {
 }
 
 func waitForGitopsReady(gitopsURL, secret, workspaceName string) error {
-	// Increase timeout for CI environments where services may take longer to start
-	maxAttempts := 120 // 4 minutes total (120 * 2 seconds)
+	// gitops boots quickly (its image is already built locally), so 3 minutes is
+	// a generous margin for CI.
+	maxAttempts := 90 // 3 minutes total (90 * 2 seconds)
 	attempt := 0
 
 	// First, wait for container to be running
@@ -1124,9 +1126,9 @@ func deployAutomation(gitopsURL, secret, workspaceName, deploymentID, checksum s
 }
 
 func waitForDeployment(gitopsURL, secret, workspaceName, deploymentID string) (string, error) {
-	// Increase timeout to 10 minutes (300 attempts * 2 seconds) for CI environments
-	// where deployments may take longer to become ready
-	maxAttempts := 300
+	// The container should reach "running" within seconds of the deploy task
+	// completing; 3 minutes is a generous margin for CI.
+	maxAttempts := 90 // 3 minutes (90 * 2 seconds)
 	attempt := 0
 
 	fmt.Printf("Waiting for deployment '%s' to be ready (timeout: %d minutes)...\n", deploymentID, maxAttempts*2/60)

--- a/cmd/test/pull_and_deploy.go
+++ b/cmd/test/pull_and_deploy.go
@@ -31,6 +31,16 @@ func newPullAndDeployCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO: Migrate this test to the workspace-mounted deploy flow.
+//
+// It deploys FastAPI to workspace 1 via gitops' asset-upload endpoints
+// (uploadAsset -> POST /automations/assets/upload, buildAutomationImage ->
+// POST /images/{name}, deployAutomation -> POST /automations/{id}/deploy), which
+// gitops removed in favour of building and deploying directly from the
+// bind-mounted workspace repo — so this test currently fails at the upload step.
+// Re-implement the initial deploy with createAutomationFromTemplate + startDeploy
+// + waitForDeployTask (see init.go), then exercise client.PullAndDeploy on
+// workspace 2. Not wired into CI (see .github/workflows/test.yml).
 func runTestPullAndDeploy(gitopsImage, editorImage string) error {
 	fmt.Println("=== BitSwan Test Suite: Pull and Deploy ===")
 	fmt.Println()

--- a/internal/config/workspace.go
+++ b/internal/config/workspace.go
@@ -45,6 +45,12 @@ func GetWorkspaceMetadata(workspaceName string) (WorkspaceMetadata, error) {
 	return metadata, nil
 }
 
+// SaveWorkspaceMetadata persists workspace metadata to its canonical location.
+func SaveWorkspaceMetadata(workspaceName string, metadata WorkspaceMetadata) error {
+	metadataPath := os.Getenv("HOME") + "/.config/bitswan/" + "workspaces/" + workspaceName + "/metadata.yaml"
+	return metadata.SaveToFile(metadataPath)
+}
+
 // SaveToFile saves the WorkspaceMetadata to a YAML file at the specified path
 func (wm *WorkspaceMetadata) SaveToFile(filePath string) error {
 	// Ensure the parent directory exists

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -904,6 +904,9 @@ func (c *Client) EnableService(serviceType, workspace string, options map[string
 	if sourceDir, ok := options["source_dir"].(string); ok {
 		reqBody.SourceDir = sourceDir
 	}
+	if staging, ok := options["staging"].(bool); ok {
+		reqBody.Staging = staging
+	}
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
@@ -1590,6 +1593,9 @@ func (c *Client) UpdateService(serviceType, workspace string, options map[string
 	}
 	if codingAgentImage, ok := options["coding_agent_image"].(string); ok {
 		reqBody.CodingAgentImage = codingAgentImage
+	}
+	if staging, ok := options["staging"].(bool); ok {
+		reqBody.Staging = staging
 	}
 
 	bodyBytes, err := json.Marshal(reqBody)

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/automations"
 	"github.com/bitswan-space/bitswan-workspaces/internal/config"
+	"github.com/bitswan-space/bitswan-workspaces/internal/dockerhub"
 	"github.com/bitswan-space/bitswan-workspaces/internal/oauth"
 	"github.com/bitswan-space/bitswan-workspaces/internal/services"
+	"github.com/google/uuid"
 )
 
 // stdoutMutex protects stdout redirection from concurrent requests
@@ -36,6 +38,7 @@ type ServiceEnableRequest struct {
 	PgAdminImage   string                 `json:"pgadmin_image,omitempty"`
 	MinioImage       string                 `json:"minio_image,omitempty"`
 	CodingAgentImage string                 `json:"coding_agent_image,omitempty"`
+	Staging          bool                   `json:"staging,omitempty"`
 	DevMode          bool                   `json:"dev_mode,omitempty"`
 	SourceDir        string                 `json:"source_dir,omitempty"`
 }
@@ -84,6 +87,7 @@ type ServiceUpdateRequest struct {
 	PgAdminImage     string `json:"pgadmin_image,omitempty"`
 	MinioImage       string `json:"minio_image,omitempty"`
 	CodingAgentImage string `json:"coding_agent_image,omitempty"`
+	Staging          bool   `json:"staging,omitempty"`
 }
 
 // ServiceBackupRequest represents the request to backup CouchDB
@@ -1053,50 +1057,52 @@ func (s *Server) handleCodingAgentEnableLocal(w http.ResponseWriter, req Service
 }
 
 func (s *Server) enableCodingAgentService(req ServiceEnableRequest) error {
+	agentService, err := services.NewCodingAgentService(req.Workspace)
+	if err != nil {
+		return fmt.Errorf("failed to create Coding Agent service: %w", err)
+	}
+
+	if agentService.IsEnabled() {
+		return fmt.Errorf("Coding Agent service is already enabled for workspace '%s'", req.Workspace)
+	}
+
 	metadata, err := config.GetWorkspaceMetadata(req.Workspace)
 	if err != nil {
 		return fmt.Errorf("failed to read workspace metadata: %w", err)
 	}
 
-	gitopsURL := fmt.Sprintf("http://%s-gitops:8079", req.Workspace)
-	ensureURL := gitopsURL + "/worktrees/coding-agent/ensure"
-
-	// Build request body with options
-	bodyMap := map[string]interface{}{}
-	if req.CodingAgentImage != "" {
-		bodyMap["image"] = req.CodingAgentImage
+	secret := metadata.CodingAgentSecret
+	if secret == "" {
+		secret = uuid.NewString()
+		metadata.CodingAgentSecret = secret
 	}
-	if req.DevMode {
-		bodyMap["dev_mode"] = true
-	}
-	if req.SourceDir != "" {
-		bodyMap["source_dir"] = req.SourceDir
+	metadata.CodingAgentEnabled = true
+	if err := config.SaveWorkspaceMetadata(req.Workspace, metadata); err != nil {
+		return fmt.Errorf("failed to save workspace metadata: %w", err)
 	}
 
-	bodyBytes, err := json.Marshal(bodyMap)
-	if err != nil {
-		return fmt.Errorf("failed to marshal request: %w", err)
+	image := req.CodingAgentImage
+	if image == "" {
+		resolved, err := dockerhub.ResolveCodingAgentImage(req.Staging)
+		if err != nil {
+			return fmt.Errorf("failed to resolve coding-agent image: %w", err)
+		}
+		image = resolved
 	}
 
-	httpReq, err := http.NewRequest("POST", ensureURL, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Authorization", "Bearer "+metadata.GitopsSecret)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("failed to call gitops ensure endpoint: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("gitops ensure failed (HTTP %d): %s", resp.StatusCode, string(body))
+	var devConfig *services.CodingAgentDevConfig
+	if req.DevMode || req.SourceDir != "" {
+		devConfig = &services.CodingAgentDevConfig{
+			DevMode:   req.DevMode,
+			SourceDir: req.SourceDir,
+		}
 	}
 
-	return nil
+	if err := agentService.Enable(secret, image, metadata.Domain, devConfig); err != nil {
+		return err
+	}
+
+	return agentService.StartContainer()
 }
 
 func (s *Server) disableCodingAgentService(workspace string) error {
@@ -1177,6 +1183,10 @@ func (s *Server) updateCodingAgentService(req ServiceUpdateRequest) error {
 	if req.CodingAgentImage != "" {
 		if err := agentService.UpdateImage(req.CodingAgentImage); err != nil {
 			return fmt.Errorf("failed to update coding-agent image: %w", err)
+		}
+	} else {
+		if err := agentService.UpdateToLatestWithStaging(req.Staging); err != nil {
+			return fmt.Errorf("failed to update coding-agent to latest: %w", err)
 		}
 	}
 

--- a/internal/daemon/workspace_init.go
+++ b/internal/daemon/workspace_init.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/aoc"
@@ -37,14 +38,17 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 	mkCerts := fs.Bool("mkcerts", false, "")
 	noIde := fs.Bool("no-ide", false, "")
 	noDashboard := fs.Bool("no-dashboard", false, "")
+	noCodingAgent := fs.Bool("no-coding-agent", false, "")
 	setHosts := fs.Bool("set-hosts", false, "")
 	local := fs.Bool("local", false, "")
 	gitopsImage := fs.String("gitops-image", "", "")
 	editorImage := fs.String("editor-image", "", "")
 	dashboardImage := fs.String("dashboard-image", "", "")
+	codingAgentImage := fs.String("coding-agent-image", "", "")
 	gitopsDevSourceDir := fs.String("gitops-dev-source-dir", "", "")
 	editorDevSourceDir := fs.String("editor-dev-source-dir", "", "")
 	dashboardDevSourceDir := fs.String("dashboard-dev-source-dir", "", "")
+	codingAgentDevSourceDir := fs.String("coding-agent-dev-source-dir", "", "")
 	oauthConfigFile := fs.String("oauth-config", "", "")
 	noOauth := fs.Bool("no-oauth", false, "")
 	sshPort := fs.String("ssh-port", "", "")
@@ -537,6 +541,26 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 		}
 	}
 
+	var bitswanCodingAgentImage string
+	if !*noCodingAgent {
+		bitswanCodingAgentImage = *codingAgentImage
+		if bitswanCodingAgentImage == "" {
+			var err error
+			bitswanCodingAgentImage, err = dockerhub.ResolveCodingAgentImage(*staging)
+			if err != nil {
+				return fmt.Errorf("failed to get latest BitSwan coding-agent image: %w", err)
+			}
+		}
+	}
+
+	// Generate the coding-agent secret up-front so it can be persisted to
+	// metadata before the service starts. The coding-agent container is started
+	// with this secret in env, and gitops re-discovers it via `docker inspect`.
+	var codingAgentSecret string
+	if !*noCodingAgent {
+		codingAgentSecret = uuid.NewString()
+	}
+
 	fmt.Println("Setting up GitOps deployment...")
 	gitopsDeployment := gitopsConfig + "/deployment"
 	if err := os.MkdirAll(gitopsDeployment, 0755); err != nil {
@@ -655,6 +679,7 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 		LocalRemotePath:    localRemotePath,
 		LocalRemoteName:    localRemoteName,
 		KeycloakURL:        keycloakURL,
+		CodingAgentSecret:  codingAgentSecret,
 	}
 	compose, token, err := config.CreateDockerComposeFile()
 
@@ -675,7 +700,7 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 	fmt.Println("GitOps deployment set up successfully!")
 
 	// Save metadata to file
-	if err := saveMetadata(gitopsConfig, workspaceName, token, *domain, *noIde, *noDashboard, &workspaceId, mqttEnvVars, *gitopsDevSourceDir, *editorDevSourceDir, *dashboardDevSourceDir); err != nil {
+	if err := saveMetadata(gitopsConfig, workspaceName, token, *domain, *noIde, *noDashboard, *noCodingAgent, &workspaceId, mqttEnvVars, *gitopsDevSourceDir, *editorDevSourceDir, *dashboardDevSourceDir, *codingAgentDevSourceDir, codingAgentSecret); err != nil {
 		fmt.Printf("Warning: Failed to save metadata: %v\n", err)
 	}
 
@@ -772,6 +797,35 @@ func (s *Server) runWorkspaceInit(args []string, confirmCh <-chan struct{}) erro
 
 		fmt.Println("------------WORKSPACE DASHBOARD INFO------------")
 		fmt.Printf("Workspace Dashboard URL: https://%s-dashboard.%s\n", workspaceName, *domain)
+	}
+
+	// Setup coding-agent service if not disabled.
+	if !*noCodingAgent {
+		fmt.Println("Setting up coding-agent service...")
+
+		codingAgentService, err := services.NewCodingAgentService(workspaceName)
+		if err != nil {
+			return fmt.Errorf("failed to create coding-agent service: %w", err)
+		}
+
+		var devConfig *services.CodingAgentDevConfig
+		if *codingAgentDevSourceDir != "" {
+			devConfig = &services.CodingAgentDevConfig{
+				DevMode:   true,
+				SourceDir: *codingAgentDevSourceDir,
+			}
+		}
+
+		if err := codingAgentService.Enable(codingAgentSecret, bitswanCodingAgentImage, *domain, devConfig); err != nil {
+			return fmt.Errorf("failed to enable coding-agent service: %w", err)
+		}
+
+		if err := codingAgentService.StartContainer(); err != nil {
+			return fmt.Errorf("failed to start coding-agent container: %w", err)
+		}
+
+		fmt.Println("------------CODING AGENT INFO------------")
+		fmt.Printf("Coding Agent container: %s-coding-agent\n", workspaceName)
 	}
 
 	fmt.Println("------------GITOPS INFO------------")
@@ -883,7 +937,7 @@ func setHostsFile(workspaceName, domain string, noIde bool) error {
 	return nil
 }
 
-func saveMetadata(gitopsConfig, workspaceName, token, domain string, noIde, noDashboard bool, workspaceId *string, mqttEnvVars []string, gitopsDevSourceDir, editorDevSourceDir, dashboardDevSourceDir string) error {
+func saveMetadata(gitopsConfig, workspaceName, token, domain string, noIde, noDashboard, noCodingAgent bool, workspaceId *string, mqttEnvVars []string, gitopsDevSourceDir, editorDevSourceDir, dashboardDevSourceDir, codingAgentDevSourceDir, codingAgentSecret string) error {
 	metadata := config.WorkspaceMetadata{
 		Domain:       domain,
 		GitopsURL:    fmt.Sprintf("https://%s-gitops.%s", workspaceName, domain),
@@ -940,6 +994,15 @@ func saveMetadata(gitopsConfig, workspaceName, token, domain string, noIde, noDa
 
 	if dashboardDevSourceDir != "" {
 		metadata.DashboardDevSourceDir = &dashboardDevSourceDir
+		metadata.DevMode = true
+	}
+
+	if !noCodingAgent {
+		metadata.CodingAgentEnabled = true
+		metadata.CodingAgentSecret = codingAgentSecret
+	}
+
+	if codingAgentDevSourceDir != "" {
 		metadata.DevMode = true
 	}
 

--- a/internal/daemon/workspace_remove.go
+++ b/internal/daemon/workspace_remove.go
@@ -78,10 +78,31 @@ func RunWorkspaceRemove(workspaceName string, writer io.Writer) error {
 	// Docker compose project names must be lowercase
 	projectName := strings.ToLower(workspaceName)
 
+	// Tear down the automations + infra (database) containers that gitops
+	// deployed at runtime. This runs regardless of whether the gitops API
+	// automation removal above succeeded, so it also covers the case where
+	// gitops is unreachable. gitops launches these under
+	// COMPOSE_PROJECT_NAME=<workspace> (Docker lowercases it) from
+	// <workspace>/gitops/docker-compose.yaml; the infra/DB services carry no
+	// gitops.* labels, so a compose-file down is the only reliable way to
+	// remove them.
+	gitopsDir := filepath.Join(workspacesFolder, workspaceName, "gitops")
+	gitopsCompose := filepath.Join(gitopsDir, "docker-compose.yaml")
+	if _, err := os.Stat(gitopsCompose); err == nil {
+		fmt.Fprintln(writer, "Removing automations and infra (database) containers deployed by gitops...")
+		cmd := exec.Command("docker", "compose", "-f", "docker-compose.yaml", "-p", projectName, "down", "--volumes")
+		cmd.Dir = gitopsDir
+		cmd.Stdout = writer
+		cmd.Stderr = writer
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(writer, "Warning: Failed to remove gitops-deployed containers/volumes: %v\n", err)
+		}
+	}
+
 	if _, err := os.Stat(dockerComposePath); os.IsNotExist(err) {
 		fmt.Fprintf(writer, "Warning: Deployment directory %s does not exist, skipping docker compose down.\n", dockerComposePath)
 		// Still try to remove containers by project name in case they exist
-		for _, projSuffix := range []string{"-site", "-editor"} {
+		for _, projSuffix := range []string{"-site", "-editor", "-dashboard", "-coding-agent"} {
 			cmd := exec.Command("docker", "compose", "-p", projectName+projSuffix, "down", "--volumes")
 			cmd.Stdout = writer
 			cmd.Stderr = writer
@@ -93,9 +114,16 @@ func RunWorkspaceRemove(workspaceName string, writer io.Writer) error {
 		composeArgs := [][]string{
 			{"-p", projectName + "-site", "down", "--volumes"},
 		}
-		editorComposePath := filepath.Join(dockerComposePath, "docker-compose-editor.yml")
-		if _, err := os.Stat(editorComposePath); err == nil {
-			composeArgs = append(composeArgs, []string{"-f", "docker-compose-editor.yml", "-p", projectName + "-editor", "down", "--volumes"})
+		// Editor, dashboard, and coding-agent each have their own compose file
+		// and project; tear down whichever are present.
+		for _, svc := range []struct{ file, suffix string }{
+			{"docker-compose-editor.yml", "-editor"},
+			{"docker-compose-dashboard.yml", "-dashboard"},
+			{"docker-compose-coding-agent.yml", "-coding-agent"},
+		} {
+			if _, err := os.Stat(filepath.Join(dockerComposePath, svc.file)); err == nil {
+				composeArgs = append(composeArgs, []string{"-f", svc.file, "-p", projectName + svc.suffix, "down", "--volumes"})
+			}
 		}
 		for _, args := range composeArgs {
 			cmd := exec.Command("docker", append([]string{"compose"}, args...)...)
@@ -112,9 +140,10 @@ func RunWorkspaceRemove(workspaceName string, writer io.Writer) error {
 	// 4. Remove images used by docker-compose
 	fmt.Fprintln(writer, "Removing images used by docker-compose...")
 	composeFiles := []string{"docker-compose.yml"}
-	editorComposePath := filepath.Join(dockerComposePath, "docker-compose-editor.yml")
-	if _, err := os.Stat(editorComposePath); err == nil {
-		composeFiles = append(composeFiles, "docker-compose-editor.yml")
+	for _, f := range []string{"docker-compose-editor.yml", "docker-compose-dashboard.yml", "docker-compose-coding-agent.yml"} {
+		if _, err := os.Stat(filepath.Join(dockerComposePath, f)); err == nil {
+			composeFiles = append(composeFiles, f)
+		}
 	}
 	for _, composeFile := range composeFiles {
 		removeImagesFromComposeFile(filepath.Join(dockerComposePath, composeFile), writer)

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -34,6 +34,7 @@ type DockerComposeConfig struct {
 	LocalRemotePath    string // Host path to local repository (if using local remote)
 	LocalRemoteName    string // Mount name for local repository (used for mount point path)
 	KeycloakURL        string // Keycloak base URL for authentication
+	CodingAgentSecret  string // Bearer token gitops uses to verify coding-agent requests
 }
 
 // CreateDockerComposeFile creates a docker-compose YAML content and returns it along with the generated secret token
@@ -102,6 +103,17 @@ func (config *DockerComposeConfig) CreateDockerComposeFileWithSecret(existingSec
 			"BITSWAN_WORKSPACE_NAME=" + config.WorkspaceName,
 			"BITSWAN_CERTS_DIR=" + homeDir + "/.config/bitswan/certauthorities",
 		},
+	}
+
+	// Authoritative coding-agent secret. With this set in gitops' env,
+	// verify_agent_token resolves directly from os.environ instead of
+	// falling back to `docker inspect` on the agent container — which
+	// would otherwise cache the first secret seen for the lifetime of
+	// the gitops process and reject any subsequent re-issued secret.
+	if config.CodingAgentSecret != "" {
+		gitopsService["environment"] = append(gitopsService["environment"].([]string),
+			"BITSWAN_GITOPS_AGENT_SECRET="+config.CodingAgentSecret,
+		)
 	}
 
 	// Add Keycloak URL if configured

--- a/internal/dockerhub/dockerhub.go
+++ b/internal/dockerhub/dockerhub.go
@@ -144,3 +144,29 @@ func ResolveEditorImage(staging bool) (string, error) {
 	}
 	return "bitswan/bitswan-editor:" + version, nil
 }
+
+// GetLatestCodingAgentVersion gets the latest version of the coding-agent image
+func GetLatestCodingAgentVersion() (string, error) {
+	return GetLatestDockerHubVersion("https://hub.docker.com/v2/repositories/bitswan/coding-agent/tags/")
+}
+
+// GetLatestCodingAgentStagingVersion gets the latest version of the coding-agent-staging image
+func GetLatestCodingAgentStagingVersion() (string, error) {
+	return GetLatestDockerHubVersion("https://hub.docker.com/v2/repositories/bitswan/coding-agent-staging/tags/")
+}
+
+// ResolveCodingAgentImage returns the full coding-agent image string based on the staging flag.
+func ResolveCodingAgentImage(staging bool) (string, error) {
+	if staging {
+		version, err := GetLatestCodingAgentStagingVersion()
+		if err != nil {
+			return "", err
+		}
+		return "bitswan/coding-agent-staging:" + version, nil
+	}
+	version, err := GetLatestCodingAgentVersion()
+	if err != nil {
+		return "", err
+	}
+	return "bitswan/coding-agent:" + version, nil
+}

--- a/internal/services/coding_agent.go
+++ b/internal/services/coding_agent.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/config"
+	"github.com/bitswan-space/bitswan-workspaces/internal/dockerhub"
 	"gopkg.in/yaml.v3"
 )
 
@@ -151,7 +152,7 @@ func (c *CodingAgentService) SaveDockerCompose(content string) error {
 }
 
 // Enable enables the Coding Agent service for the workspace
-func (c *CodingAgentService) Enable(gitopsAgentSecret, codingAgentImage, domain string) error {
+func (c *CodingAgentService) Enable(gitopsAgentSecret, codingAgentImage, domain string, devConfig *CodingAgentDevConfig) error {
 	// Check if already enabled
 	if c.IsEnabled() {
 		return fmt.Errorf("Coding Agent service is already enabled for workspace '%s'", c.WorkspaceName)
@@ -202,7 +203,7 @@ func (c *CodingAgentService) Enable(gitopsAgentSecret, codingAgentImage, domain 
 	}
 
 	// Generate docker-compose content
-	dockerComposeContent, err := c.CreateDockerCompose(gitopsAgentSecret, codingAgentImage, domain)
+	dockerComposeContent, err := c.CreateDockerComposeWithDevMode(gitopsAgentSecret, codingAgentImage, domain, devConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create docker-compose content: %w", err)
 	}
@@ -342,4 +343,21 @@ func (c *CodingAgentService) UpdateImage(newImage string) error {
 	}
 
 	return nil
+}
+
+// UpdateToLatest updates the coding-agent service to the latest version from DockerHub
+func (c *CodingAgentService) UpdateToLatest() error {
+	return c.UpdateImage("")
+}
+
+// UpdateToLatestWithStaging updates the coding-agent service to the latest version from DockerHub, optionally using staging
+func (c *CodingAgentService) UpdateToLatestWithStaging(staging bool) error {
+	if staging {
+		version, err := dockerhub.GetLatestCodingAgentStagingVersion()
+		if err != nil {
+			return fmt.Errorf("failed to get latest staging version: %w", err)
+		}
+		return c.UpdateImage("bitswan/coding-agent-staging:" + version)
+	}
+	return c.UpdateToLatest()
 }


### PR DESCRIPTION
- coding agent is deployed as standalone service during workspace init instead of gitops deploying it
- workspace remove command also removes dashboard, coding agent and automation+db containers